### PR TITLE
feat: Add a possibility to change the color of dropdown icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ On Android, specifies how to display the selection items when the user taps on t
 
 ---
 
+### `dropdownIconColor`
+
+On Android, specifies color of dropdown triangle. Input value should be hexadecimal string
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | Android  |
+
+---
+
 ### `prompt`
 
 Prompt string for this picker, used on Android in dialog mode as the title of the dialog.

--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
@@ -24,6 +24,8 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import javax.annotation.Nullable;
+import android.graphics.PorterDuff;
+import android.graphics.Color;
 
 /**
  * {@link ViewManager} for the {@link ReactPicker} view. This is abstract because the
@@ -69,6 +71,11 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
   @ReactProp(name = "selected")
   public void setSelected(ReactPicker view, int selected) {
     view.setStagedSelection(selected);
+  }
+
+  @ReactProp(name = "dropdownIconColor") 
+  public void setDropdownIconColor(ReactPicker view, @Nullable String color) {
+    view.getBackground().setColorFilter(Color.parseColor("#ffffff"), PorterDuff.Mode.SRC_ATOP);
   }
 
   @Override

--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
@@ -75,7 +75,7 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
 
   @ReactProp(name = "dropdownIconColor") 
   public void setDropdownIconColor(ReactPicker view, @Nullable String color) {
-    view.getBackground().setColorFilter(Color.parseColor("#ffffff"), PorterDuff.Mode.SRC_ATOP);
+    view.getBackground().setColorFilter(Color.parseColor(color), PorterDuff.Mode.SRC_ATOP);
   }
 
   @Override

--- a/example/src/PickerExample.tsx
+++ b/example/src/PickerExample.tsx
@@ -55,6 +55,17 @@ function PromptPickerExample() {
   );
 }
 
+function CustomDropdownArrowColorPickerExample() {
+  return (
+    <View>
+      <Picker dropdownIconColor="#ffffff">
+        <Item label="hello" value="key0" />
+        <Item label="world" value="key1" />
+      </Picker>
+    </View>
+  );
+};
+
 function NoListenerPickerExample() {
   return (
     <View>
@@ -131,5 +142,9 @@ export const examples = [
   {
     title: 'Colorful pickers',
     render: ColorPickerExample,
+  },
+  {
+    title: 'Picker with changed color of arrow',
+    render: CustomDropdownArrowColorPickerExample,
   },
 ];

--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -41,7 +41,7 @@ type PickerAndroidProps = $ReadOnly<{|
   onValueChange?: ?(itemValue: ?(string | number), itemIndex: number) => mixed,
   prompt?: ?string,
   testID?: string,
-  dropdownIconColor?: string;
+  dropdownIconColor?: string,
 |}>;
 
 type Item = $ReadOnly<{|

--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -41,6 +41,7 @@ type PickerAndroidProps = $ReadOnly<{|
   onValueChange?: ?(itemValue: ?(string | number), itemIndex: number) => mixed,
   prompt?: ?string,
   testID?: string,
+  dropdownIconColor?: string;
 |}>;
 
 type Item = $ReadOnly<{|
@@ -103,6 +104,7 @@ class PickerAndroid extends React.Component<
       prompt: this.props.prompt,
       selected: this.state.selectedIndex,
       testID: this.props.testID,
+      dropdownIconColor: this.props.dropdownIconColor,
       style: [styles.pickerAndroid, this.props.style],
       /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
        * when making Flow check .android.js files. */

--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -51,6 +51,10 @@ export interface PickerProps extends ViewProps {
    * Used to locate this view in end-to-end tests.
    */
   testID?: string;
+   /**
+    * Color of arrow for spinner dropdown in hexadecimal format
+    */
+   dropdownIconColor?: string;
 }
 
 declare class Picker extends React.Component<PickerProps, {}> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
This pull request adds the possibility to set a color for dropdown arrow for Spinner component on Android.
Related issue is this: https://github.com/react-native-community/react-native-picker/issues/47
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Add the property `dropdownIconColor='#ffffff'` for example, to see the updated color of arrow

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
