### PR TITLE
fix: [Android] fixed index with null child

### DIFF
--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -67,10 +67,7 @@ class PickerAndroid extends React.Component<
     props: PickerAndroidProps,
   ): PickerAndroidState {
     let selectedIndex = 0;
-    const items = React.Children.map(props.children, (child, index) => {
-      if (child === null) {
-        return;
-      }
+    const items = React.Children.toArray(props.children).map((child, index) => {
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }


### PR DESCRIPTION
This PR fixes bug on Android when Picker.Item is null, but its index is taken into account