### PR TITLE
fix: Adjust typing of Picker.Item to conform with implementation #176

### DIFF
--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -4,8 +4,8 @@ import { TextStyle, StyleProp, ViewProps } from 'react-native'
 export type ItemValue  = number | string
 
 export interface PickerItemProps {
-	label?: string;
-	value: ItemValue;
+	label: string;
+	value?: ItemValue;
 	color?: string;
 	testID?: string;
 }


### PR DESCRIPTION
This PR fixes the typescript definition of Picker.Item to conform with the implementation.