### PR TITLE
fix: Fix compilation and rendering on macOS

### DIFF
--- a/js/PickerMacOS.macos.js
+++ b/js/PickerMacOS.macos.js
@@ -151,7 +151,7 @@ const styles = StyleSheet.create({
     // The picker will conform to whatever width is given, but we do
     // have to set the component's height explicitly on the
     // surrounding view to ensure it gets rendered.
-    height: 216,
+    height: 20,
   },
 });
 

--- a/macos/RNCPicker.h
+++ b/macos/RNCPicker.h
@@ -15,7 +15,7 @@
 @property (nonatomic, assign) NSInteger selectedIndex;
 
 @property (nonatomic, strong) NSColor *color;
-@property (nonatomic, strong) NSFont *font;
+@property (nonatomic, strong) NSFont *customFont;
 @property (nonatomic, assign) NSTextAlignment textAlign;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;

--- a/macos/RNCPicker.m
+++ b/macos/RNCPicker.m
@@ -20,11 +20,11 @@
 {
     if ((self = [super initWithFrame:frame pullsDown:false])) {
         _color = [NSColor blackColor];
-        _font  = [NSFont systemFontOfSize:21];
+        _customFont  = [NSFont systemFontOfSize:14];
         _selectedIndex = NSNotFound;
         _textAlign     = NSTextAlignmentCenter;
         [self selectItemAtIndex:0];
-        [[self menu] setFont:_font];
+        [[self menu] setFont:_customFont];
         self.pullsDown = false;
         [self setAction:@selector(mySelector:)];
         [self setTarget:self];
@@ -47,7 +47,7 @@
         NSColor *color = [RCTConvert NSColor:item[@"textColor"]] ?: _color;
         NSMenuItem * row = [self itemArray][index];
         NSDictionary *attributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                    color, NSForegroundColorAttributeName, _font, NSFontAttributeName, paragraphStyle, NSParagraphStyleAttributeName ,nil];
+                                    color, NSForegroundColorAttributeName, _customFont, NSFontAttributeName, paragraphStyle, NSParagraphStyleAttributeName ,nil];
         NSAttributedString *as = [[NSAttributedString alloc]
                     initWithString:[row title]
                     attributes:attributes];


### PR DESCRIPTION
This fixes #185 

1. Fixes compilation on macOS the _font property was overwriting some other inherited property and that was causing troubles
2. Fixes the height to be closer to the native component real height, otherwise rendering is very broken