### PR TITLE
fix: picker declaration

### DIFF
--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -61,11 +61,11 @@ declare class Picker extends React.Component<PickerProps, {}> {
    /**
      * On Android, display the options in a dialog.
      */
-    static MODE_DIALOG: string;
+    static readonly MODE_DIALOG: 'dialog';
     /**
      * On Android, display the options in a dropdown (this is the default).
      */
-    static MODE_DROPDOWN: string;
+    static readonly MODE_DROPDOWN: 'dropdown';
 
    static Item: React.ComponentType<PickerItemProps>;
 }

--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -59,11 +59,11 @@ export interface PickerProps extends ViewProps {
 
 declare class Picker extends React.Component<PickerProps, {}> {
    /**
-     * On Android, display the options in a dialog.
+     * On Android, display the options in a dialog (this is the default).
      */
     static readonly MODE_DIALOG: 'dialog';
     /**
-     * On Android, display the options in a dropdown (this is the default).
+     * On Android, display the options in a dropdown.
      */
     static readonly MODE_DROPDOWN: 'dropdown';
 


### PR DESCRIPTION
* Use literal type to avoid typescript warning while assigning `mode` prop of Picker using the static constant: `mode={Picker.MODE_DIALOG}`
* Fix android default picker mode comment for intellisense