### PR TITLE
fix: Fix macOS picker not correctly setting controlled value

### DIFF
--- a/js/PickerMacOS.macos.js
+++ b/js/PickerMacOS.macos.js
@@ -154,7 +154,7 @@ const styles = StyleSheet.create({
     // The picker will conform to whatever width is given, but we do
     // have to set the component's height explicitly on the
     // surrounding view to ensure it gets rendered.
-    height: 20,
+    height: 24,
   },
 });
 

--- a/macos/RNCPicker.m
+++ b/macos/RNCPicker.m
@@ -20,15 +20,15 @@
 {
     if ((self = [super initWithFrame:frame pullsDown:false])) {
         _color = [NSColor blackColor];
-        _customFont  = [NSFont systemFontOfSize:14];
+        _customFont = [NSFont systemFontOfSize:14];
         _selectedIndex = NSNotFound;
-        _textAlign     = NSTextAlignmentCenter;
+        _textAlign = NSTextAlignmentCenter;
+
         [self selectItemAtIndex:0];
         [[self menu] setFont:_customFont];
         self.pullsDown = false;
         [self setAction:@selector(mySelector:)];
         [self setTarget:self];
-
     }
     return self;
 }
@@ -54,8 +54,8 @@
         [row setAttributedTitle:as];
         index++;
     }
-    [self setNeedsLayout:true];
 
+    [self setNeedsLayout:true];
 }
 
 
@@ -64,7 +64,7 @@
   if (_selectedIndex != selectedIndex) {
     _selectedIndex = selectedIndex;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self setSelectedIndex:selectedIndex];
+        [self selectItemAtIndex:selectedIndex];
     });
   }
 }


### PR DESCRIPTION
As mentioned on #187, the macOS picker was not correctly setting the correct index when passed a value, the internal method was calling itself instead of the NSPopUp method for setting the selected index

Also fixes the height a bit to correctly show the entire picker box