### PR TITLE
fix: add accessibilityIdentifier to testID

### DIFF
--- a/ios/RNCPicker.m
+++ b/ios/RNCPicker.m
@@ -95,6 +95,7 @@ numberOfRowsInComponent:(__unused NSInteger)component
 
   label.textAlignment = _textAlign;
   label.text = [self pickerView:pickerView titleForRow:row forComponent:component];
+  label.accessibilityIdentifier = _items[row][@"testID"];
   return label;
 }
 


### PR DESCRIPTION
Unfortunately I missed one line of code in my previous PR.

- set accessibilityIdentifier to testID manually for each item in the Objective-C code.