### PR TITLE
fix: Update Picker.d.ts

### DIFF
--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -3,25 +3,25 @@ import { TextStyle, StyleProp, ViewProps } from 'react-native'
 
 export type ItemValue  = number | string
 
-export interface PickerItemProps {
-	label: string;
-	value?: ItemValue;
+export interface PickerItemProps<T = ItemValue> {
+	label?: string;
+	value?: T;
 	color?: string;
 	testID?: string;
 }
 
-export interface PickerProps extends ViewProps {
+export interface PickerProps<T = ItemValue> extends ViewProps {
 	style?: StyleProp<TextStyle>;
 	/**
    * Value matching value of one of the items. Can be a string or an integer.
    */
-	selectedValue?: ItemValue;
+	selectedValue?: T;
 	/**
    * Callback for when an item is selected. This is called with the following parameters:
    *   - `itemValue`: the `value` prop of the item that was selected
    *   - `itemIndex`: the index of the selected item in this picker
    */
-	onValueChange?: (itemValue: ItemValue, itemIndex: number) => void;
+	onValueChange?: (itemValue: T, itemIndex: number) => void;
 	/**
    * If set to false, the picker will be disabled, i.e. the user will not be able to make a
    * selection.
@@ -57,7 +57,7 @@ export interface PickerProps extends ViewProps {
    dropdownIconColor?: string;
 }
 
-declare class Picker extends React.Component<PickerProps, {}> {
+declare class Picker<T> extends React.Component<PickerProps<T>, {}> {
    /**
      * On Android, display the options in a dialog (this is the default).
      */
@@ -67,7 +67,7 @@ declare class Picker extends React.Component<PickerProps, {}> {
      */
     static readonly MODE_DROPDOWN: 'dropdown';
 
-   static Item: React.ComponentType<PickerItemProps>;
+     static Item: React.ComponentType<PickerItemProps<T>>;
 }
 
 export {Picker};


### PR DESCRIPTION
onValueChange gives me a Typescript error:

```
Overload 1 of 2, '(props: Readonly<PickerProps>): Picker', gave the following error.
    Type '(value: string) => void' is not assignable to type '(itemValue: string | number, itemIndex: number) => void'.
      Types of parameters 'value' and 'itemValue' are incompatible.
        Type 'string | number' is not assignable to type 'string'.
```
This is due to enforcing that value is of type `ItemValue` which could be both number and string.  (In my case value is supposed to be a string, not a number.)

This way Typescript should pick up on the type of `selectedValue` to determine whether `value` in `onValueChange` is number or string