### PR TITLE
fix: Update Picker.d.ts

### DIFF
--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -68,7 +68,7 @@ declare class Picker<T> extends React.Component<PickerProps<T>, {}> {
      */
     static readonly MODE_DROPDOWN: 'dropdown';
 
-     static Item: React.ComponentType<PickerItemProps<T>>;
+     static Item: React.ComponentType<PickerItemProps<ItemValue>>;
 }
 
 export {Picker};


### PR DESCRIPTION
Fix for https://github.com/react-native-picker/picker/issues/216

My original PR was to get `onValueChange?: (itemValue: T, itemIndex: number) => void;` to infer the right type for `itemValue`, but I also added T to the type of Item, which doesn't work since it's a static value on picker.

Let me know if you can think of a better way to fix this?
