### PR TITLE
fix: allow variables for dropdownIconColor

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
@@ -75,8 +75,8 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
   }
 
   @ReactProp(name = "dropdownIconColor")
-  public void setDropdownIconColor(ReactPicker view, @Nullable String color) {
-    view.getBackground().setColorFilter(Color.parseColor(color), PorterDuff.Mode.SRC_ATOP);
+  public void setDropdownIconColor(ReactPicker view, @Nullable int color) {
+    view.getBackground().setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
   }
 
   @ReactProp(name = ViewProps.NUMBER_OF_LINES, defaultInt = 1)

--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -120,7 +120,7 @@ function PickerAndroid(props: PickerAndroidProps): React.Node {
     selected,
     style: props.style,
     backgroundColor: props.backgroundColor,
-    dropdownIconColor: props.dropdownIconColor,
+    dropdownIconColor: processColor(props.dropdownIconColor),
     testID: props.testID,
     numberOfLines: props.numberOfLines,
   };


### PR DESCRIPTION
fixes crash on Android when using string variables for dropdownIconColor 