### PR TITLE
feat: disable picker item

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,65 @@ such that the total number of lines does not exceed this number. Default is '1'
 | ------- | -------- | -------- |
 | number  | No       | Android  |
 
+## PickerItemProps
+
+Props that can be applied to individual `Picker.Item`
+
+### `label`
+
+Displayed value on the Picker Item
+
+| Type    | Required | 
+| ------- | -------- | 
+| string  | yes       | 
+
+
+### `value`
+
+Actual value on the Picker Item
+
+| Type    | Required |
+| ------- | -------- |
+| number,string | yes     |
+
+### `color`
+
+Displayed color on the Picker Item
+
+| Type    | Required | 
+| ------- | -------- | 
+| string  | no       | 
+
+
+### `fontFamily`
+
+Displayed fontFamily on the Picker Item
+
+| Type    | Required |
+| ------- | -------- |
+| string  | no      | 
+
+
+### `style`
+
+Style to apply to individual item labels.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| ViewStyleProp  | no       | Android  |
+
+
+### `enabled`
+
+If set to false, the specific item will be disabled, i.e. the user will not be able to make a selection
+
+@defailt: true
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean  | no       | Android  |
+
+
 ### PickerIOS
 ### Props
 

--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
@@ -171,6 +171,7 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
     private View getView(int position, View convertView, ViewGroup parent, boolean isDropdown) {
       ReadableMap item = getItem(position);
       @Nullable ReadableMap style = null;
+      boolean enabled = true;
 
       if (item.hasKey("style")) {
         style = item.getMap("style");
@@ -183,6 +184,14 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
         convertView = mInflater.inflate(layoutResId, parent, false);
       }
 
+      if (item.hasKey("enabled")) {
+        enabled = item.getBoolean("enabled");
+      }
+
+      convertView.setEnabled(enabled);
+      // Seems counter intuitive, but this makes the specific item not clickable when enable={false}
+      convertView.setClickable(!enabled);
+      
       final TextView textView = (TextView) convertView;
       textView.setText(item.getString("label"));
       textView.setMaxLines(mNumberOfLines);

--- a/example/src/PickerExample.tsx
+++ b/example/src/PickerExample.tsx
@@ -57,6 +57,18 @@ function DisabledPickerExample() {
   );
 }
 
+function DisabledSpecificPickerExample() {
+  const [value] = React.useState('key1');
+
+  return (
+    <Picker selectedValue={value}>
+      <Item label="hello" value="key0" enabled={true} />
+      <Item label="world" value="key1" />
+      <Item label="disabled" value="key2" enabled={false} />
+    </Picker>
+  );
+}
+
 function DropdownPickerExample() {
   const [value, setValue] = React.useState('key1');
 
@@ -202,6 +214,10 @@ export const examples = [
   {
     title: 'Disabled Picker',
     render: DisabledPickerExample,
+  },
+  {
+    title: 'Disabled Specific Picker',
+    render: DisabledSpecificPickerExample,
   },
   {
     title: 'Dropdown Picker',

--- a/js/AndroidDialogPickerNativeComponent.js
+++ b/js/AndroidDialogPickerNativeComponent.js
@@ -12,40 +12,13 @@
 
 import {requireNativeComponent} from 'react-native';
 
-import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
-import type {
-  TextStyleProp,
-  ViewStyleProp,
-} from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type {TextStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {NativeComponent} from 'react-native/Libraries/Renderer/shims/ReactNative';
-
-type PickerAndroidChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
-    position: number,
-  |}>,
->;
-
-type Item = $ReadOnly<{|
-  label: string,
-  value: ?(number | string),
-  color?: ?number,
-  fontFamily: ?string,
-  /**
-   * Style to apply to individual item labels.
-   * Only following values take effect:
-   *   - 'color'
-   *   - 'backgroundColor'
-   *   - 'fontSize'
-   *   - 'fontFamily'
-   *
-   * @platform android
-   */
-  style?: ?ViewStyleProp,
-|}>;
+import type {PickerAndroidChangeEvent, PickerItem} from './types';
 
 type NativeProps = $ReadOnly<{|
   enabled?: ?boolean,
-  items: $ReadOnlyArray<Item>,
+  items: $ReadOnlyArray<PickerItem>,
   mode?: ?('dialog' | 'dropdown'),
   onSelect?: (event: PickerAndroidChangeEvent) => void,
   selected: number,

--- a/js/AndroidDropdownPickerNativeComponent.js
+++ b/js/AndroidDropdownPickerNativeComponent.js
@@ -12,40 +12,13 @@
 
 import {requireNativeComponent} from 'react-native';
 
-import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
-import type {
-  TextStyleProp,
-  ViewStyleProp,
-} from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type {TextStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {NativeComponent} from 'react-native/Libraries/Renderer/shims/ReactNative';
-
-type PickerAndroidChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
-    position: number,
-  |}>,
->;
-
-type Item = $ReadOnly<{|
-  label: string,
-  value: ?(number | string),
-  color?: ?number,
-  fontFamily: ?string,
-  /**
-   * Style to apply to individual item labels.
-   * Only following values take effect:
-   *   - 'color'
-   *   - 'backgroundColor'
-   *   - 'fontSize'
-   *   - 'fontFamily'
-   *
-   * @platform android
-   */
-  style?: ?ViewStyleProp,
-|}>;
+import type {PickerAndroidChangeEvent, PickerItem} from './types';
 
 type NativeProps = $ReadOnly<{|
   enabled?: ?boolean,
-  items: $ReadOnlyArray<Item>,
+  items: $ReadOnlyArray<PickerItem>,
   mode?: ?('dialog' | 'dropdown'),
   onSelect?: (event: PickerAndroidChangeEvent) => void,
   selected: number,

--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -50,6 +50,9 @@ function PickerAndroid(props: PickerAndroidProps): React.Node {
       if (child.props.value === props.selectedValue) {
         selected = index;
       }
+
+      const {enabled = true} = child.props;
+
       const {color, label, style = {}} = child.props;
 
       const processedColor = processColor(color);
@@ -57,6 +60,7 @@ function PickerAndroid(props: PickerAndroidProps): React.Node {
       return {
         color: color == null ? null : processedColor,
         label,
+        enabled,
         style: {
           ...style,
           color: style.color ? processColor(style.color) : null,

--- a/js/types.js
+++ b/js/types.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
+
+export type PickerAndroidChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    position: number,
+  |}>,
+>;
+
+export type PickerItem = $ReadOnly<{|
+  label: string,
+  value: ?(number | string),
+  color?: ?number,
+  fontFamily: ?string,
+  /**
+   * Style to apply to individual item labels.
+   * Only following values take effect:
+   *   - 'color'
+   *   - 'backgroundColor'
+   *   - 'fontSize'
+   *   - 'fontFamily'
+   *
+   * @platform android
+   */
+  style?: ?ViewStyleProp,
+  /**
+   * If set to false, the specific item will be disabled, i.e. the user will not be able to make a
+   * selection.
+   * @default true
+   * @platform android
+   */
+  enabled?: ?boolean,
+|}>;

--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -19,7 +19,14 @@ export interface PickerItemProps<T = ItemValue> {
    * 
    * @platform android
    */
-  style? : StyleProp<TextStyle>
+  style?: StyleProp<TextStyle>
+  /**
+   * If set to false, the specific item will be disabled, i.e. the user will not be able to make a
+   * selection.
+   * @default true
+   * @platform android
+   */
+  enabled?:boolean
 }
 
 export interface PickerProps<T = ItemValue> extends ViewProps {


### PR DESCRIPTION
fix #207 fix #126 

Add `enabled` property to `Picker.Item` that will allow users to disable individual items on android


<img src="https://user-images.githubusercontent.com/6936373/113233646-a8f3ae00-92da-11eb-9a04-2de547fb6a46.png" width="320"/>