### PR TITLE
Fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Style to apply to individual item labels.
 
 If set to false, the specific item will be disabled, i.e. the user will not be able to make a selection
 
-@defailt: true
+@default: true
 
 | Type    | Required | Platform |
 | ------- | -------- | -------- |


### PR DESCRIPTION
Probably there is a small typo in README.md:

wrong: defailt
correct: default