### PR TITLE
fix: [Android] fixed index with null child

### DIFF
--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -43,7 +43,7 @@ function PickerAndroid(props: PickerAndroidProps): React.Node {
     // eslint-disable-next-line no-shadow
     let selected = 0;
     // eslint-disable-next-line no-shadow
-    const items = React.Children.map(props.children, (child, index) => {
+    const items = React.Children.toArray(props.children).map((child, index) => {
       if (child === null) {
         return null;
       }


### PR DESCRIPTION
This PR is the same as [PR 174](https://github.com/react-native-picker/picker/pull/174), but that fix was rewritten