### PR TITLE
chore: export props from index

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import {Picker} from "./Picker"
+import {Picker, PickerProps, PickerItemProps} from "./Picker"
 import {PickerIOS} from "./PickerIOS"
 
-export {Picker, PickerIOS};
+export {Picker, PickerIOS, PickerProps, PickerItemProps};


### PR DESCRIPTION
Hi! Thanks for writing this library. This PR exposes the `PickerProps` and `PickerItemProps` from the main package export.

This allows importing the types like this:
```ts
import { PickerProps } from "@react-native-picker/picker";
```

Instead of:
```ts
import { PickerProps } from "@react-native-picker/picker/typings/Picker";
```