### PR TITLE
fix: Fix typings by importing missing NativeSyntheticEvent and TargetedEvent

### DIFF
--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -1,12 +1,12 @@
 import * as React from "react"
-import { TextStyle, StyleProp, ViewProps } from 'react-native'
+import { TextStyle, StyleProp, ViewProps, NativeSyntheticEvent, TargetedEvent } from 'react-native'
 
-export type ItemValue  = number | string
+export type ItemValue = number | string
 
 export interface PickerItemProps<T = ItemValue> {
    label?: string;
-	value?: T;
-	color?: string;
+   value?: T;
+   color?: string;
    fontFamily?: string,
    testID?: string;
    /**
@@ -16,7 +16,7 @@ export interface PickerItemProps<T = ItemValue> {
     *   - 'backgroundColor'
     *   - 'fontSize'
     *   - 'fontFamily'
-    * 
+    *
     * @platform android
     */
    style?: StyleProp<TextStyle>
@@ -26,28 +26,28 @@ export interface PickerItemProps<T = ItemValue> {
     * @default true
     * @platform android
     */
-   enabled?:boolean
+   enabled?: boolean
 }
 
 export interface PickerProps<T = ItemValue> extends ViewProps {
-	style?: StyleProp<TextStyle>;
-	/**
+   style?: StyleProp<TextStyle>;
+   /**
    * Value matching value of one of the items. Can be a string or an integer.
    */
-	selectedValue?: T;
-	/**
+   selectedValue?: T;
+   /**
    * Callback for when an item is selected. This is called with the following parameters:
    *   - `itemValue`: the `value` prop of the item that was selected
    *   - `itemIndex`: the index of the selected item in this picker
    */
-	onValueChange?: (itemValue: T, itemIndex: number) => void;
-	/**
+   onValueChange?: (itemValue: T, itemIndex: number) => void;
+   /**
    * If set to false, the picker will be disabled, i.e. the user will not be able to make a
    * selection.
    * @platform android
    */
-	enabled?: boolean;
-	/**
+   enabled?: boolean;
+   /**
    * On Android, specifies how to display the selection items when the user taps on the picker:
    *
    *   - 'dialog': Show a modal dialog. This is the default.
@@ -55,25 +55,25 @@ export interface PickerProps<T = ItemValue> extends ViewProps {
    *
    * @platform android
    */
-	mode?: 'dialog' | 'dropdown';
-	/**
+   mode?: 'dialog' | 'dropdown';
+   /**
    * Style to apply to each of the item labels.
    * @platform ios
    */
-	itemStyle?: StyleProp<TextStyle>;
-	/**
+   itemStyle?: StyleProp<TextStyle>;
+   /**
    * Prompt string for this picker, used on Android in dialog mode as the title of the dialog.
    * @platform android
    */
-	prompt?: string;
-	/**
+   prompt?: string;
+   /**
    * Used to locate this view in end-to-end tests.
    */
    testID?: string;
-    /**
-     * Color of arrow for spinner dropdown in hexadecimal format
-     * @platform android
-     */
+   /**
+    * Color of arrow for spinner dropdown in hexadecimal format
+    * @platform android
+    */
    dropdownIconColor?: string;
    /**
    * On Android, used to truncate the text with an ellipsis after computing the text layout, including line wrapping,

--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -1,53 +1,59 @@
-import * as React from "react"
-import { TextStyle, StyleProp, ViewProps, NativeSyntheticEvent, TargetedEvent } from 'react-native'
+import * as React from 'react';
+import {
+  TextStyle,
+  StyleProp,
+  ViewProps,
+  NativeSyntheticEvent,
+  TargetedEvent,
+} from 'react-native';
 
-export type ItemValue = number | string
+export type ItemValue = number | string;
 
 export interface PickerItemProps<T = ItemValue> {
-   label?: string;
-   value?: T;
-   color?: string;
-   fontFamily?: string,
-   testID?: string;
-   /**
-    * Style to apply to individual item labels.
-    * Only following values take effect:
-    *   - 'color'
-    *   - 'backgroundColor'
-    *   - 'fontSize'
-    *   - 'fontFamily'
-    *
-    * @platform android
-    */
-   style?: StyleProp<TextStyle>
-   /**
-    * If set to false, the specific item will be disabled, i.e. the user will not be able to make a
-    * selection.
-    * @default true
-    * @platform android
-    */
-   enabled?: boolean
+  label?: string;
+  value?: T;
+  color?: string;
+  fontFamily?: string;
+  testID?: string;
+  /**
+   * Style to apply to individual item labels.
+   * Only following values take effect:
+   *   - 'color'
+   *   - 'backgroundColor'
+   *   - 'fontSize'
+   *   - 'fontFamily'
+   *
+   * @platform android
+   */
+  style?: StyleProp<TextStyle>;
+  /**
+   * If set to false, the specific item will be disabled, i.e. the user will not be able to make a
+   * selection.
+   * @default true
+   * @platform android
+   */
+  enabled?: boolean;
 }
 
 export interface PickerProps<T = ItemValue> extends ViewProps {
-   style?: StyleProp<TextStyle>;
-   /**
+  style?: StyleProp<TextStyle>;
+  /**
    * Value matching value of one of the items. Can be a string or an integer.
    */
-   selectedValue?: T;
-   /**
+  selectedValue?: T;
+  /**
    * Callback for when an item is selected. This is called with the following parameters:
    *   - `itemValue`: the `value` prop of the item that was selected
    *   - `itemIndex`: the index of the selected item in this picker
    */
-   onValueChange?: (itemValue: T, itemIndex: number) => void;
-   /**
+  onValueChange?: (itemValue: T, itemIndex: number) => void;
+  /**
    * If set to false, the picker will be disabled, i.e. the user will not be able to make a
    * selection.
    * @platform android
    */
-   enabled?: boolean;
-   /**
+  enabled?: boolean;
+  /**
    * On Android, specifies how to display the selection items when the user taps on the picker:
    *
    *   - 'dialog': Show a modal dialog. This is the default.
@@ -55,68 +61,68 @@ export interface PickerProps<T = ItemValue> extends ViewProps {
    *
    * @platform android
    */
-   mode?: 'dialog' | 'dropdown';
-   /**
+  mode?: 'dialog' | 'dropdown';
+  /**
    * Style to apply to each of the item labels.
    * @platform ios
    */
-   itemStyle?: StyleProp<TextStyle>;
-   /**
+  itemStyle?: StyleProp<TextStyle>;
+  /**
    * Prompt string for this picker, used on Android in dialog mode as the title of the dialog.
    * @platform android
    */
-   prompt?: string;
-   /**
+  prompt?: string;
+  /**
    * Used to locate this view in end-to-end tests.
    */
-   testID?: string;
-   /**
-    * Color of arrow for spinner dropdown in hexadecimal format
-    * @platform android
-    */
-   dropdownIconColor?: string;
-   /**
+  testID?: string;
+  /**
+   * Color of arrow for spinner dropdown in hexadecimal format
+   * @platform android
+   */
+  dropdownIconColor?: string;
+  /**
    * On Android, used to truncate the text with an ellipsis after computing the text layout, including line wrapping,
    * such that the total number of lines does not exceed this number. Default is '1'
    * @platform android
    */
-   numberOfLines?: number;
-   /**
-    * The string used for the accessibility label. Will be read once focused on the picker but not on change.
-    */
-   accessibilityLabel?: string;
-   /**
-    * Called when picker is focused
-    * @platform android
-    */
-   onFocus?: (e: NativeSyntheticEvent<TargetedEvent>) => void
-   /**
-    * Called when picker is blurred
-    * @platform android
-    */
-   onBlur?: (e: NativeSyntheticEvent<TargetedEvent>) => void
+  numberOfLines?: number;
+  /**
+   * The string used for the accessibility label. Will be read once focused on the picker but not on change.
+   */
+  accessibilityLabel?: string;
+  /**
+   * Called when picker is focused
+   * @platform android
+   */
+  onFocus?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
+  /**
+   * Called when picker is blurred
+   * @platform android
+   */
+  onBlur?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
 }
 
 declare class Picker<T> extends React.Component<PickerProps<T>, {}> {
-   /**
-     * On Android, display the options in a dialog (this is the default).
-     */
-   static readonly MODE_DIALOG: 'dialog';
-   /**
-    * On Android, display the options in a dropdown.
-    */
-   static readonly MODE_DROPDOWN: 'dropdown';
+  /**
+   * On Android, display the options in a dialog (this is the default).
+   */
+  static readonly MODE_DIALOG: 'dialog';
+  /**
+   * On Android, display the options in a dropdown.
+   */
+  static readonly MODE_DROPDOWN: 'dropdown';
 
-   static Item: React.ComponentType<PickerItemProps<ItemValue>>;
+  static Item: React.ComponentType<PickerItemProps<ItemValue>>;
 
-   /**
-    * @platform android
-    */
-   focus: () => void
-   /**
-    * @platform android
-    */
-   blur: () => void
+  /**
+   * @platform android
+   */
+  focus: () => void;
+  /**
+   * @platform android
+   */
+  blur: () => void;
 }
 
 export { Picker };

--- a/typings/PickerIOS.d.ts
+++ b/typings/PickerIOS.d.ts
@@ -1,27 +1,27 @@
-import * as React from "react"
-import { TextStyle, StyleProp, ViewProps } from 'react-native'
-import { ItemValue } from "./Picker"
+import * as React from 'react';
+import {TextStyle, StyleProp, ViewProps} from 'react-native';
+import {ItemValue} from './Picker';
 
 export interface PickerIOSItemProps {
-	label?: string;
-	value?: number | string;
-	color?: string;
-	testID?: string;
+  label?: string;
+  value?: number | string;
+  color?: string;
+  testID?: string;
 }
 
 declare class PickerIOSItem extends React.Component<PickerIOSItemProps, {}> {}
 
 export interface PickerIOSProps extends ViewProps {
-	itemStyle?: StyleProp<TextStyle>;
-	style?: StyleProp<TextStyle>;
-	onChange?: React.SyntheticEvent<{itemValue: ItemValue, itemIndex: number}>;
-	onValueChange?: (itemValue: ItemValue, itemIndex: number) => void;
-	selectedValue?: ItemValue;
-	testID?: string;
+  itemStyle?: StyleProp<TextStyle>;
+  style?: StyleProp<TextStyle>;
+  onChange?: React.SyntheticEvent<{itemValue: ItemValue, itemIndex: number}>;
+  onValueChange?: (itemValue: ItemValue, itemIndex: number) => void;
+  selectedValue?: ItemValue;
+  testID?: string;
 }
 
 declare class PickerIOS extends React.Component<PickerIOSProps, {}> {
-	static Item: typeof PickerIOSItem
+  static Item: typeof PickerIOSItem;
 }
 
-export { PickerIOS };
+export {PickerIOS};

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import {Picker, PickerProps, PickerItemProps} from "./Picker"
-import {PickerIOS} from "./PickerIOS"
+import {Picker, PickerProps, PickerItemProps} from './Picker';
+import {PickerIOS} from './PickerIOS';
 
 export {Picker, PickerIOS, PickerProps, PickerItemProps};


### PR DESCRIPTION
After updating to the v1.16.3 release I got the following typescript issues in my project:

```
$ tsc
node_modules/@react-native-picker/picker/typings/Picker.d.ts:92:18 - error TS2304: Cannot find name 'NativeSyntheticEvent'.

92    onFocus?: (e: NativeSyntheticEvent<TargetedEvent>) => void
                    ~~~~~~~~~~~~~~~~~~~~

node_modules/@react-native-picker/picker/typings/Picker.d.ts:92:39 - error TS2304: Cannot find name 'TargetedEvent'.

92    onFocus?: (e: NativeSyntheticEvent<TargetedEvent>) => void
                                         ~~~~~~~~~~~~~

node_modules/@react-native-picker/picker/typings/Picker.d.ts:97:17 - error TS2304: Cannot find name 'NativeSyntheticEvent'.

97    onBlur?: (e: NativeSyntheticEvent<TargetedEvent>) => void
                   ~~~~~~~~~~~~~~~~~~~~

node_modules/@react-native-picker/picker/typings/Picker.d.ts:97:38 - error TS2304: Cannot find name 'TargetedEvent'.

97    onBlur?: (e: NativeSyntheticEvent<TargetedEvent>) => void
                                        ~~~~~~~~~~~~~


Found 4 errors.
```


I've updated the imports in the Picker.d.ts to fix the issues. I ran prettier on the files in typings/ to fix the inconsistencies in formatting