### PR TITLE
make PickerItemProps accept generic value rather than just ItemValue

### DIFF
--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -113,7 +113,7 @@ declare class Picker<T> extends React.Component<PickerProps<T>, {}> {
    */
   static readonly MODE_DROPDOWN: 'dropdown';
 
-  static Item: React.ComponentType<PickerItemProps<ItemValue>>;
+  static Item: React.ComponentType<PickerItemProps<T>>;
 
   /**
    * @platform android


### PR DESCRIPTION
Made `PickerItemProps` accept a generic `T` so that pickers are typed so they can hold data other than `ItemValue`
If this typing decision was intentional, feel free to close this PR :)
