### PR TITLE
Android Sdk Version 16 compatibility (vectorDrawables.useSupportLibrary)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+    vectorDrawables.useSupportLibrary = true
   }
 }
 


### PR DESCRIPTION
 Hello! 
 Using react-native-picker/picker on a Android project with `minSdkVersion = 16` provoked the following error
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-picker_picker:packageDebugResources'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > Error while processing /Users/******/*******/*******/*********/node_modules/@react-native-picker/picker/android/src/main/res/drawable/ic_dropdown.xml : Can't process attribute android:fillColor="@android:color/black": references to other resources are not supported by build-time PNG generation.
     File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)
     See http://developer.android.com/tools/help/vector-asset-studio.html for details.
```

 Searching for a solution my team and I found a section in the [Android documentation talking about vector compatibility](https://developer.android.com/guide/topics/graphics/vector-drawable-resources#vector-drawables-backward-solution) and worked!
 
  ```
    //For Gradle Plugin 2.0+
     android {
       defaultConfig {
         vectorDrawables.useSupportLibrary = true
        }
     }
```

If you have any comment, please, let's start a talk! ;D

Special thanks for the awesome team that Im in @Jcgama, @VictorCaldas, @pamelasouza