### PR TITLE
fix: Android min sdk 16 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+    vectorDrawables.useSupportLibrary getExtOrDefault('vector_drawable_use_support_library')
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
-    vectorDrawables.useSupportLibrary getExtOrDefault('vector_drawable_use_support_library')
+    vectorDrawables.useSupportLibrary=getExtOrDefault('vector_drawable_use_support_library')
   }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,4 @@ ReactNativePicker_compileSdkVersion=28
 ReactNativePicker_buildToolsVersion=28.0.3
 ReactNativePicker_targetSdkVersion=28
 ReactNativePicker_minSdkVersion=21
+ReactNativePicker_vector_drawable_use_support_library=true


### PR DESCRIPTION
The purpose of this PR is to fix the bellow error:

<details>
<summary>Stack Trace</summary>

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-picker_picker:packageDebugResources'.
> Error: 6 exceptions were raised by workers:
  java.lang.RuntimeException: java.lang.RuntimeException: Error while processing /Users/reberthkelvin/Projects/Delfos/delfos_im/DelfosimApp/node_modules/@react-native-picker/picker/android/src/main/res/drawable/ic_dropdown.xml : Can't process attribute android:fillColor="@android:color/black": references to other resources are not supported by build-time PNG generation.
  File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)
  See http://developer.android.com/tools/help/vector-asset-studio.html for details.
  java.lang.RuntimeException: java.lang.RuntimeException: Error while processing /Users/reberthkelvin/Projects/Delfos/delfos_im/DelfosimApp/node_modules/@react-native-picker/picker/android/src/main/res/drawable/ic_dropdown.xml : Can't process attribute android:fillColor="@android:color/black": references to other resources are not supported by build-time PNG generation.
  File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)
  See http://developer.android.com/tools/help/vector-asset-studio.html for details.
  java.lang.RuntimeException: java.lang.RuntimeException: Error while processing /Users/reberthkelvin/Projects/Delfos/delfos_im/DelfosimApp/node_modules/@react-native-picker/picker/android/src/main/res/drawable/ic_dropdown.xml : Can't process attribute android:fillColor="@android:color/black": references to other resources are not supported by build-time PNG generation.
  File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)
  See http://developer.android.com/tools/help/vector-asset-studio.html for details.
  java.lang.RuntimeException: java.lang.RuntimeException: Error while processing /Users/reberthkelvin/Projects/Delfos/delfos_im/DelfosimApp/node_modules/@react-native-picker/picker/android/src/main/res/drawable/ic_dropdown.xml : Can't process attribute android:fillColor="@android:color/black": references to other resources are not supported by build-time PNG generation.
  File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)
  See http://developer.android.com/tools/help/vector-asset-studio.html for details.
  java.lang.RuntimeException: java.lang.RuntimeException: Error while processing /Users/reberthkelvin/Projects/Delfos/delfos_im/DelfosimApp/node_modules/@react-native-picker/picker/android/src/main/res/drawable/ic_dropdown.xml : Can't process attribute android:fillColor="@android:color/black": references to other resources are not supported by build-time PNG generation.
  File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)
  See http://developer.android.com/tools/help/vector-asset-studio.html for details.
  java.lang.RuntimeException: java.lang.RuntimeException: Error while processing /Users/reberthkelvin/Projects/Delfos/delfos_im/DelfosimApp/node_modules/@react-native-picker/picker/android/src/main/res/drawable/ic_dropdown.xml : Can't process attribute android:fillColor="@android:color/black": references to other resources are not supported by build-time PNG generation.
  File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)
  See http://developer.android.com/tools/help/vector-asset-studio.html for details.
```

</details>

Ref: https://stackoverflow.com/questions/51325513/cant-process-attribute-androidfillcolor-androidcolor-white/53846109#53846109