### PR TITLE
fix: Build Web without Flowtype

### DIFF
--- a/js/Picker.web.js
+++ b/js/Picker.web.js
@@ -10,8 +10,6 @@ import {forwardRef, useRef} from 'react';
 import type {ViewProps} from 'react-native-web/src/exports/View/types';
 import type {GenericStyleProp} from 'react-native-web/src/types';
 import type {TextStyle} from 'react-native-web/src/exports/Text/types';
-// $FlowFixMe fallback for older react-native-web versions
-import {createElement, unstable_createElement} from 'react-native';
 import PickerItem from './PickerItem';
 
 type PickerProps = {
@@ -31,10 +29,12 @@ type PickerProps = {
   prompt?: string,
 };
 
-const myCreateElement = createElement || unstable_createElement;
+const createElement =
+  require('react-native-web').createElement ||
+  require('react-native-web').unstable_createElement;
 
 const Select = forwardRef((props: any, forwardedRef) =>
-  myCreateElement('select', props),
+  createElement('select', props),
 );
 
 const Picker: React$AbstractComponent<PickerProps, empty> = forwardRef<

--- a/js/PickerAndroid.js
+++ b/js/PickerAndroid.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import UnimplementedView from 'react-native/Libraries/Components/UnimplementedViews/UnimplementedView';
+import UnimplementedView from './UnimplementedView';
 
 /**
  * Fallback for non-android platforms

--- a/js/PickerAndroid.web.js
+++ b/js/PickerAndroid.web.js
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react';
-import UnimplementedView from 'react-native-web/src/modules/UnimplementedView';
+import UnimplementedView from './UnimplementedView';
 
 function PickerAndroid(): React.Node {
   return <UnimplementedView />;

--- a/js/PickerIOS.js
+++ b/js/PickerIOS.js
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react';
-import UnimplementedView from 'react-native/Libraries/Components/UnimplementedViews/UnimplementedView';
+import UnimplementedView from './UnimplementedView';
 
 function PickerIOS(): React.Node {
   return <UnimplementedView />;

--- a/js/PickerIOS.web.js
+++ b/js/PickerIOS.web.js
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react';
-import UnimplementedView from 'react-native-web/src/modules/UnimplementedView';
+import UnimplementedView from './UnimplementedView';
 
 function PickerIOS(): React.Node {
   return <UnimplementedView />;

--- a/js/PickerItem.js
+++ b/js/PickerItem.js
@@ -7,9 +7,6 @@
 
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-// $FlowFixMe
-import {createElement, unstable_createElement} from 'react-native';
-
 import * as React from 'react';
 
 type Props = {
@@ -19,9 +16,11 @@ type Props = {
   value?: number | string,
 };
 
-const myCreateElement = createElement || unstable_createElement;
+const createElement =
+  require('react-native-web').createElement ||
+  require('react-native-web').unstable_createElement;
 
-const Option = (props: any) => myCreateElement('option', props);
+const Option = (props: any) => createElement('option', props);
 
 export default function PickerItem({
   color,

--- a/js/PickerMacOS.js
+++ b/js/PickerMacOS.js
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import UnimplementedView from 'react-native/Libraries/Components/UnimplementedViews/UnimplementedView';
+import UnimplementedView from './UnimplementedView';
 class PickerMacOS extends React.Component<{}> {
   static Item: typeof UnimplementedView = UnimplementedView;
   render(): React.Node {

--- a/js/PickerMacOS.web.js
+++ b/js/PickerMacOS.web.js
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react';
-import UnimplementedView from 'react-native-web/src/modules/UnimplementedView';
+import UnimplementedView from './UnimplementedView';
 
 function PickerMacOS(): React.Node {
   return <UnimplementedView />;

--- a/js/PickerWindows.js
+++ b/js/PickerWindows.js
@@ -7,6 +7,6 @@
 
 'use strict';
 
-import UnimplementedView from 'react-native/Libraries/Components/UnimplementedViews/UnimplementedView';
+import UnimplementedView from './UnimplementedView';
 
 export default UnimplementedView;

--- a/js/PickerWindows.web.js
+++ b/js/PickerWindows.web.js
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react';
-import UnimplementedView from 'react-native-web/src/modules/UnimplementedView';
+import UnimplementedView from './UnimplementedView';
 
 function PickerWindows(): React.Node {
   return <UnimplementedView />;

--- a/js/UnimplementedView.js
+++ b/js/UnimplementedView.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import * as React from 'react';
+import {View, StyleSheet} from 'react-native';
+declare var __DEV__: boolean;
+/**
+ * Common implementation for a simple stubbed view. Simply applies the view's styles to the inner
+ * View component and renders its children.
+ */
+const UnimplementedView = (props: $FlowFixMeProps): React.Node => {
+  return (
+    <View style={[styles.unimplementedView, props.style]}>
+      {props.children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  unimplementedView: __DEV__
+    ? {
+        alignSelf: 'flex-start',
+        borderColor: 'red',
+        borderWidth: 1,
+      }
+    : {},
+});
+
+module.exports = UnimplementedView;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "include": ["typings/**/*.d.ts"],
+  "include": [
+    "typings/**/*.d.ts"
+  ],
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
@@ -16,10 +18,16 @@
     "skipLibCheck": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "lib": ["es2015", "es2016", "esnext", "dom"]
+    "lib": [
+      "es2015",
+      "es2016",
+      "esnext",
+      "dom"
+    ]
   },
   "exclude": [
     "node_modules",
     "**/*.spec.ts"
-  ]
+  ],
+  "extends": "expo/tsconfig.base"
 }


### PR DESCRIPTION
Fix #238 
Added UnimplementedView and changed way of importing createElement for web so that picker can be used on web without needing to strip flow code
