### PR TITLE
fix: unimplemented view export

### DIFF
--- a/js/UnimplementedView.web.js
+++ b/js/UnimplementedView.web.js
@@ -26,13 +26,14 @@ const UnimplementedView = (props: $FlowFixMeProps): React.Node => {
 };
 
 const styles = StyleSheet.create({
-  unimplementedView: __DEV__
-    ? {
-        alignSelf: 'flex-start',
-        borderColor: 'red',
-        borderWidth: 1,
-      }
-    : {},
+  unimplementedView:
+    process.env.NODE_ENV !== 'production'
+      ? {
+          alignSelf: 'flex-start',
+          borderColor: 'red',
+          borderWidth: 1,
+        }
+      : {},
 });
 
 export default UnimplementedView;


### PR DESCRIPTION
fixes #100 fixes #134

Fix Unimplemented View so that it can be imported from create-react-app project without modifying webpack