### PR TITLE
fix: Fixed dynamic imports of react-native-web

### DIFF
--- a/js/Picker.web.js
+++ b/js/Picker.web.js
@@ -6,6 +6,7 @@
  */
 
 import * as React from 'react';
+import * as ReactNativeWeb from 'react-native-web';
 import {forwardRef, useRef} from 'react';
 import type {ViewProps} from 'react-native-web/src/exports/View/types';
 import type {GenericStyleProp} from 'react-native-web/src/types';
@@ -30,8 +31,7 @@ type PickerProps = {
 };
 
 const createElement =
-  require('react-native-web').createElement ||
-  require('react-native-web').unstable_createElement;
+  ReactNativeWeb.createElement || ReactNativeWeb.unstable_createElement;
 
 const Select = forwardRef((props: any, forwardedRef) =>
   createElement('select', props),

--- a/js/PickerItem.js
+++ b/js/PickerItem.js
@@ -8,6 +8,7 @@
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import * as React from 'react';
+import * as ReactNativeWeb from 'react-native-web';
 
 type Props = {
   color?: ColorValue,
@@ -18,8 +19,7 @@ type Props = {
 };
 
 const createElement =
-  require('react-native-web').createElement ||
-  require('react-native-web').unstable_createElement;
+  ReactNativeWeb.createElement || ReactNativeWeb.unstable_createElement;
 
 const Option = (props: any) => createElement('option', props);
 


### PR DESCRIPTION
The dynamic imports in the web part are causing issues together with `react-native-web`, `electron` and `vite` as bundler.

With a proper configuration, electron disallows the `require` statement, and it's very tricky to solve this require errors with `vite`. It's better to use `import`.