### PR TITLE
BREAKING CHANGE: remove createElement usage in react-native-web

### DIFF
--- a/js/Picker.web.js
+++ b/js/Picker.web.js
@@ -30,11 +30,8 @@ type PickerProps = {
   prompt?: string,
 };
 
-const createElement =
-  ReactNativeWeb.createElement || ReactNativeWeb.unstable_createElement;
-
 const Select = forwardRef((props: any, forwardedRef) =>
-  createElement('select', props),
+  ReactNativeWeb.unstable_createElement('select', props),
 );
 
 const Picker: React$AbstractComponent<PickerProps, empty> = forwardRef<

--- a/js/PickerItem.js
+++ b/js/PickerItem.js
@@ -18,10 +18,8 @@ type Props = {
   value?: number | string,
 };
 
-const createElement =
-  ReactNativeWeb.createElement || ReactNativeWeb.unstable_createElement;
-
-const Option = (props: any) => createElement('option', props);
+const Option = (props: any) =>
+  ReactNativeWeb.unstable_createElement('option', props);
 
 /**
  * PickerItem Component for React Native Web


### PR DESCRIPTION
Remove createElement usage & use `unstable_createElement` in web instead [as it has been renamed in react-native-web v0.12.0](https://github.com/necolas/react-native-web/releases/tag/0.12.0)

Resolve #355

Tested by running example in web, as I'm only changing the web part
![Kapture 2022-01-04 at 20 27 34](https://user-images.githubusercontent.com/24470609/148066089-06410bcd-9de7-4468-83d4-747ed069c17e.gif)

