### PR TITLE
fix: add ref support for Web

### DIFF
--- a/js/Picker.web.js
+++ b/js/Picker.web.js
@@ -31,7 +31,10 @@ type PickerProps = {
 };
 
 const Select = forwardRef((props: any, forwardedRef) =>
-  ReactNativeWeb.unstable_createElement('select', {...props, ref: forwardedRef}),
+  ReactNativeWeb.unstable_createElement('select', {
+    ...props,
+    ref: forwardedRef,
+  }),
 );
 
 const Picker: React$AbstractComponent<PickerProps, empty> = forwardRef<
@@ -48,7 +51,7 @@ const Picker: React$AbstractComponent<PickerProps, empty> = forwardRef<
     dropdownIconColor,
     ...other
   } = props;
-  
+
   const handleChange = React.useCallback<any>(
     (e: Object) => {
       const {selectedIndex, value} = e.target;

--- a/js/Picker.web.js
+++ b/js/Picker.web.js
@@ -7,7 +7,7 @@
 
 import * as React from 'react';
 import * as ReactNativeWeb from 'react-native-web';
-import {forwardRef, useRef} from 'react';
+import {forwardRef} from 'react';
 import type {ViewProps} from 'react-native-web/src/exports/View/types';
 import type {GenericStyleProp} from 'react-native-web/src/types';
 import type {TextStyle} from 'react-native-web/src/exports/Text/types';
@@ -31,7 +31,7 @@ type PickerProps = {
 };
 
 const Select = forwardRef((props: any, forwardedRef) =>
-  ReactNativeWeb.unstable_createElement('select', props),
+  ReactNativeWeb.unstable_createElement('select', {...props, ref: forwardedRef}),
 );
 
 const Picker: React$AbstractComponent<PickerProps, empty> = forwardRef<
@@ -48,9 +48,7 @@ const Picker: React$AbstractComponent<PickerProps, empty> = forwardRef<
     dropdownIconColor,
     ...other
   } = props;
-
-  const hostRef = useRef(null);
-
+  
   const handleChange = React.useCallback<any>(
     (e: Object) => {
       const {selectedIndex, value} = e.target;
@@ -66,7 +64,7 @@ const Picker: React$AbstractComponent<PickerProps, empty> = forwardRef<
     <Select
       disabled={enabled === false ? true : undefined}
       onChange={handleChange}
-      ref={hostRef}
+      ref={forwardedRef}
       value={selectedValue}
       {...other}
     />


### PR DESCRIPTION
A few changes on `forwardedRef` allows anyone to pass a React `ref`on Web version and get a ref of `<select>` tag that renders `Picker`. I am currently using a forked version with these changes in order to get `focus( )` method of `<select>` tag and avoid dirty code. 

Let me know guys what do you think. I am fully available to make any changes neccesary.