### PR TITLE
fix: Workaround XAML bug with ComboBox and dark theme

### DIFF
--- a/windows/ReactNativePicker/ReactPickerView.cpp
+++ b/windows/ReactNativePicker/ReactPickerView.cpp
@@ -6,9 +6,9 @@
 #include "ReactPickerView.h"
 #include "ReactPickerView.g.cpp"
 
-#include <UI.Xaml.Media.h>
 #include <winrt/Windows.Foundation.Metadata.h>
 #include <UI.Xaml.Input.h>
+#include <UI.Xaml.Media.h>
 
 namespace winrt {
     using namespace Microsoft::ReactNative;

--- a/windows/ReactNativePicker/ReactPickerView.h
+++ b/windows/ReactNativePicker/ReactPickerView.h
@@ -25,6 +25,7 @@ namespace winrt::ReactNativePicker::implementation {
         xaml::Media::Brush m_comboBoxColor{ nullptr };
         xaml::Controls::ComboBox::SelectionChanged_revoker m_selectionChangedRevoker{};
         xaml::Controls::ComboBox::DropDownClosed_revoker m_dropDownClosedRevoker{};
+        xaml::Controls::ComboBox::DropDownOpened_revoker m_dropDownOpenedRevoker{};
 
         void RegisterEvents();
         void RepopulateItems(winrt::Microsoft::ReactNative::JSValueArray const& items);


### PR DESCRIPTION
Currently picker does not support darkMode (at least in our XamlIsland based app).
This issues seems to be identical to: https://github.com/microsoft/microsoft-ui-xaml/issues/2331.
The solution is based of https://github.com/microsoft/react-native-windows/pull/8777/files
.
Before:
<img width="969" alt="1" src="https://user-images.githubusercontent.com/484044/155031491-c78a8ca3-dcb8-4ce9-90fb-0342705881ca.png">

After
<img width="967" alt="2" src="https://user-images.githubusercontent.com/484044/155031525-0159b3c2-ee37-49a2-af70-077d0e35eed7.png">

