### PR TITLE
Use textColor instead of blackColor in RNCPicker MacOS

### DIFF
--- a/macos/RNCPicker.m
+++ b/macos/RNCPicker.m
@@ -19,7 +19,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
     if ((self = [super initWithFrame:frame pullsDown:false])) {
-        _color = [NSColor blackColor];
+        _color = [NSColor textColor];
         _customFont = [NSFont systemFontOfSize:14];
         _selectedIndex = NSNotFound;
         _textAlign = NSTextAlignmentCenter;


### PR DESCRIPTION
By using textColor instead of blackColor the color will adjust based on the system appearance (supporting dark/light mode)