### PR TITLE
fix: Fixing accessibility label on Windows.

### DIFF
--- a/js/PickerWindows.windows.js
+++ b/js/PickerWindows.windows.js
@@ -35,6 +35,7 @@ type PickerWindowsProps = $ReadOnly<{|
   testID?: string,
   onChange?: (event: IPickerChangeEvent) => void,
   onValueChange?: (value: any, itemIndex: number, text: string) => void,
+  accessibilityLabel?: ?string,
   // Editable support
   editable?: boolean,
   text?: string,
@@ -92,6 +93,7 @@ class PickerWindows extends React.Component<
       selectedIndex: this.state.selectedIndex,
       testID: this.props.testID,
       style: [styles.pickerWindows, this.props.style, this.props.itemStyle],
+      accessibilityLabel: this.props.accessibilityLabel
     };
 
     return (


### PR DESCRIPTION
This partially fixes #310, for Windows only.

Tested locally with the app that I'm building - the React Native Windows framework handles the accessibility label properly, but it was not originally passed through props.

Let me know if I'm missing anything!