### PR TITLE
fix: adding deprecated-react-native-prop-types to support react-native 0.69 and above

### DIFF
--- a/js/PickerIOS.ios.js
+++ b/js/PickerIOS.ios.js
@@ -19,7 +19,7 @@ import RNCPickerNativeComponent from './RNCPickerNativeComponent';
 import type {RNCPickerIOSType} from './RNCPickerNativeComponent';
 import type {ProcessedColorValue} from 'react-native/Libraries/StyleSheet/processColor';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {ViewProps} from 'deprecated-react-native-prop-types';
 import type {TextStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {Element, ElementRef, ChildrenArray} from 'react';

--- a/js/PickerMacOS.macos.js
+++ b/js/PickerMacOS.macos.js
@@ -20,7 +20,7 @@ import RNCPickerNativeComponent from './RNCPickerNativeComponent';
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {ProcessedColorValue} from 'react-native/Libraries/StyleSheet/processColor';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {ViewProps} from 'deprecated-react-native-prop-types';
 import type {TextStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {Element, ElementRef, ChildrenArray} from 'react';
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react": ">=16",
-    "react-native": ">=0.57"
+    "react-native": ">=0.57",
+    "deprecated-react-native-prop-types": "^2.3.0"
   },
   "private": false,
   "devDependencies": {


### PR DESCRIPTION
The correct fix here is to switch to deprecated-react-native-prop-types or a type system like Typescript.
Back in 2018 [facebook/react-native started removing](https://github.com/facebook/react-native/issues/21342) PropTypes from React Native. Last year, in 0.68 they introduced a deprecation warning which notified users that the change is coming, and in 0.69 we removed the PropTypes entirely.