### PR TITLE
fix: Item backgroundColor fix

### DIFF
--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -105,7 +105,7 @@ function PickerAndroid(props: PickerAndroidProps, ref: PickerRef): React.Node {
         style: {
           ...style,
           color: style.color ? processColor(style.color) : null,
-          backgroundColor: style.color
+          backgroundColor: style.backgroundColor
             ? processColor(style.backgroundColor)
             : null,
         },


### PR DESCRIPTION
Fixes an issue where `backgroundColor` is not passed to the `Item` object without `color` being passed through `style` prop