### PR TITLE
fix: Issue 294 - selection color

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ return <Picker
 - [`mode`](#mode)
 - [`prompt`](#prompt)
 - [`itemStyle`](#itemstyle)
+- [`selectionColor`](#selectionColor)
 
 ---
 
@@ -320,6 +321,12 @@ such that the total number of lines does not exceed this number. Default is '1'
 | --------- | -------- | -------- |
 | function  | no       | Android  |
 
+### `selectionColor`
+
+| Type      | Required | Platform |
+| ------- | -------- | -------- |
+| ColorValue  | no       | iOS  |
+
 ## Methods
 
 ### `blur` (Android only, lib version 1.16.0+)
@@ -396,6 +403,7 @@ If set to false, the specific item will be disabled, i.e. the user will not be a
 - [`itemStyle`](#itemstyle)
 - [`onValueChange`](#onvaluechange)
 - [`selectedValue`](#selectedvalue)
+- [`selectionColor`](#selectionColor)
 - [`themeVariant`](#themeVariant)
 
 ---
@@ -425,6 +433,14 @@ If set to false, the specific item will be disabled, i.e. the user will not be a
 | Type | Required |
 | ---- | -------- |
 | any  | No       |
+
+---
+
+### `selectionColor`
+
+| Type      | Required | Platform |
+| ------- | -------- | -------- |
+| ColorValue  | no       | iOS  |
 
 ---
 

--- a/example/src/PickerIOSExample.tsx
+++ b/example/src/PickerIOSExample.tsx
@@ -132,6 +132,7 @@ function PickerStyleExample() {
     <PickerIOS
       itemStyle={styles.item}
       selectedValue={carMake}
+      selectionColor="rgba(0, 0, 0, 0.3)"
       onValueChange={(value) => setCarMake(value)}>
       {Object.keys(CAR_MAKES_AND_MODELS).map((value) => (
         <PickerIOS.Item

--- a/ios/RNCPicker.h
+++ b/ios/RNCPicker.h
@@ -15,6 +15,7 @@
 
 @property (nonatomic, copy) NSArray<NSDictionary *> *items;
 @property (nonatomic, assign) NSInteger selectedIndex;
+@property (nonatomic, assign) NSInteger selectionColor;
 
 @property (nonatomic, strong) UIColor *color;
 @property (nonatomic, strong) UIFont *font;

--- a/ios/RNCPicker.m
+++ b/ios/RNCPicker.m
@@ -20,9 +20,10 @@
   if ((self = [super initWithFrame:frame])) {
     _color = [UIColor blackColor];
     _font = [UIFont systemFontOfSize:21]; // TODO: selected title default should be 23.5
-    _selectedIndex = NSNotFound;
-    _textAlign = NSTextAlignmentCenter;
     _numberOfLines = 1;
+    _selectedIndex = NSNotFound;
+    _selectionColor = 0;
+    _textAlign = NSTextAlignmentCenter;
     self.delegate = self;
     self.dataSource = self;
     [self selectRow:0 inComponent:0 animated:YES]; // Workaround for missing selection indicator lines (see https://stackoverflow.com/questions/39564660/uipickerview-selection-indicator-not-visible-in-ios10)
@@ -108,6 +109,12 @@ numberOfRowsInComponent:(__unused NSInteger)component
     [view insertSubview:label atIndex:0];
   }
 
+  if (@available(iOS 14.0, *)) {
+      if (_selectionColor) {
+          pickerView.subviews[1].backgroundColor = [RCTConvert UIColor:@(_selectionColor)];
+      }
+  }
+    
   RNCPickerLabel* label = view.subviews[0];
   label.font = _font;
 

--- a/ios/RNCPickerManager.m
+++ b/ios/RNCPickerManager.m
@@ -22,6 +22,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(items, NSArray<NSDictionary *>)
 RCT_EXPORT_VIEW_PROPERTY(selectedIndex, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(selectionColor, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textAlign, NSTextAlignment)

--- a/js/PickerIOS.ios.js
+++ b/js/PickerIOS.ios.js
@@ -44,10 +44,11 @@ type Props = $ReadOnly<{|
   ...ViewProps,
   children: ChildrenArray<Element<typeof PickerIOSItem>>,
   itemStyle?: ?TextStyleProp,
+  numberOfLines: ?number,
   onChange?: ?(event: PickerIOSChangeEvent) => mixed,
   onValueChange?: ?(itemValue: string | number, itemIndex: number) => mixed,
   selectedValue: ?(number | string),
-  numberOfLines: ?number,
+  selectionColor: ?string,
   themeVariant: ?string,
 |}>;
 
@@ -99,19 +100,21 @@ class PickerIOS extends React.Component<Props, State> {
     if (numberOfLines < 1) {
       numberOfLines = 1;
     }
+
     return (
       <View style={this.props.style}>
         <RNCPickerNativeComponent
           ref={(picker) => {
             this._picker = picker;
           }}
-          themeVariant={this.props.themeVariant}
-          testID={this.props.testID}
-          style={[styles.pickerIOS, this.props.itemStyle]}
           items={this.state.items}
-          selectedIndex={this.state.selectedIndex}
-          onChange={this._onChange}
           numberOfLines={numberOfLines}
+          onChange={this._onChange}
+          selectedIndex={this.state.selectedIndex}
+          selectionColor={processColor(this.props.selectionColor)}
+          style={[styles.pickerIOS, this.props.itemStyle]}
+          testID={this.props.testID}
+          themeVariant={this.props.themeVariant}
         />
       </View>
     );

--- a/js/RNCPickerNativeComponent.js
+++ b/js/RNCPickerNativeComponent.js
@@ -35,11 +35,12 @@ type Label = Stringish | number;
 export type RNCPickerIOSType = HostComponent<
   $ReadOnly<{|
     items: $ReadOnlyArray<RNCPickerIOSTypeItemType>,
+    numberOfLines?: ?number,
     onChange: (event: PickerIOSChangeEvent) => void,
     selectedIndex: number,
+    selectionColor?: ?ProcessedColorValue,
     style?: ?TextStyleProp,
     testID?: ?string,
-    numberOfLines?: ?number,
     themeVariant?: ?string,
   |}>,
 >;

--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -70,6 +70,11 @@ export interface PickerProps<T = ItemValue> extends ViewProps {
    */
   itemStyle?: StyleProp<TextStyle>;
   /**
+  * Color to apply to the selection indicator.
+  * @platform ios
+  */
+  selectionColor?: ColorValue;
+  /**
    * Prompt string for this picker, used on Android in dialog mode as the title of the dialog.
    * @platform android
    */


### PR DESCRIPTION
This PR addresses #294 by adding an iOS only property called `selectionColor`, which is then set to the proper sub-view of the UIPicker.  The example project & docs have also been updated.

❓ My purposes for completing work on this functionality were to make the selection transparent so that I could show two pickers side by side with one a single selection indictor rendered in JS.  In using the `transparent` color, I noticed the indicator still shows up, but I know that `transparent` is equal to `#00000000` which seemingly should be the same as `#FFFFFF00` but it's not... using the later gave me what I wanted.

The question being, would you like for me to account for this in the JS or let the user deal with it if they happen find it?  I can easily make a single line that translates `transparent`, but someone may use it on a black background... could be based on theme if given? 

