### PR TITLE
feat: preserve white spaces on Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,15 @@ such that the total number of lines does not exceed this number. Default is '1'
 | ------- | -------- | -------- |
 | ColorValue  | no       | iOS  |
 
+### `preserveSpacesInLabel`
+
+If set to true, the items label will be displayed with spaces preserved.
+
+@default false
+| Type      | Required | Platform |
+| ------- | -------- | -------- |
+| boolean  | no       | Web |
+
 ## Methods
 
 ### `blur` (Android only, lib version 1.16.0+)

--- a/example/src/PickerExample.tsx
+++ b/example/src/PickerExample.tsx
@@ -104,6 +104,25 @@ function DropdownMultilinePickerExample() {
   );
 }
 
+function DropdownPreserveWhiteSpacesPickerExample() {
+  const [value, setValue] = React.useState('key1');
+
+  return (
+    <Picker
+      numberOfLines={5}
+      selectedValue={value}
+      onValueChange={(v) => setValue(v)}
+      mode="dropdown"
+      preserveSpacesInLabel>
+      <Item label="Lorem    ipsum dolor sit amet" value="key0" />
+      <Item
+        label="quis nostrud exercitation ullamco   laboris nisi ut aliquip ex ea commodo consequat."
+        value="key1"
+      />
+    </Picker>
+  );
+}
+
 function PromptPickerExample() {
   const [value, setValue] = React.useState('key1');
   return (
@@ -293,6 +312,10 @@ export const examples = [
   {
     title: 'Multiline Dropdown Picker',
     render: DropdownMultilinePickerExample,
+  },
+  {
+    title: 'Preserve White Space Dropdown Picker',
+    render: DropdownPreserveWhiteSpacesPickerExample,
   },
   {
     title: 'Picker with prompt message',

--- a/js/Picker.web.js
+++ b/js/Picker.web.js
@@ -28,6 +28,7 @@ type PickerProps = {
   itemStyle?: GenericStyleProp<TextStyle>,
   mode?: string,
   prompt?: string,
+  preserveSpacesInLabel?: boolean,
 };
 
 const Select = forwardRef((props: any, forwardedRef) =>
@@ -69,8 +70,17 @@ const Picker: React$AbstractComponent<PickerProps, empty> = forwardRef<
       onChange={handleChange}
       ref={forwardedRef}
       value={selectedValue}
-      {...other}
-    />
+      {...other}>
+      {React.Children.map(other.children, (child) => {
+        if (React.isValidElement(child)) {
+          let cloneElement = React.cloneElement(child, {
+            preserveSpacesInLabel: other.preserveSpacesInLabel || false,
+          });
+
+          return cloneElement;
+        }
+      })}
+    </Select>
   );
 });
 

--- a/js/PickerItem.js
+++ b/js/PickerItem.js
@@ -10,12 +10,17 @@ import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import * as React from 'react';
 import * as ReactNativeWeb from 'react-native-web';
 
+const preserveSpaces = (label: string) => {
+  return label.replace(/ /g, '\u00a0');
+};
+
 type Props = {
   color?: ColorValue,
   label: string,
   testID?: string,
   enabled?: boolean,
   value?: number | string,
+  preserveSpacesInLabel?: boolean,
 };
 
 const Option = (props: any) =>
@@ -31,15 +36,18 @@ export default function PickerItem({
   testID,
   value,
   enabled = true,
+  preserveSpacesInLabel = false,
 }: Props): React.Node {
+  const pickerLabel = preserveSpacesInLabel ? preserveSpaces(label) : label;
+
   return (
     <Option
       disabled={enabled === false ? true : undefined}
       style={{color}}
       testID={testID}
       value={value}
-      label={label}>
-      {label}
+      label={pickerLabel}>
+      {pickerLabel}
     </Option>
   );
 }

--- a/js/types.js
+++ b/js/types.js
@@ -39,4 +39,10 @@ export type PickerItem = $ReadOnly<{|
    * @platform android
    */
   enabled?: ?boolean,
+  /**
+   * If set to true, the specific item will be displayed with spaces preserved.
+   * default false
+   * @platform web
+   */
+  preserveSpacesInLabel?: ?boolean,
 |}>;

--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -35,6 +35,12 @@ export interface PickerItemProps<T = ItemValue> {
    * @platform android | web
    */
   enabled?: boolean;
+  /**
+   * If set to true, the specific item will be displayed with spaces preserved.
+   * default false
+   * @platform web
+   */
+  preserveSpacesInLabel?: ?boolean,
 }
 
 export interface PickerProps<T = ItemValue> extends ViewProps {
@@ -118,7 +124,14 @@ export interface PickerProps<T = ItemValue> extends ViewProps {
    * @platform android
    */
   onBlur?: (e: NativeSyntheticEvent<TargetedEvent>) => void;
+  /**
+   * If set to true, the items label will be displayed with spaces preserved.
+   * default false
+   * @platform web
+   */
+  preserveSpacesInLabel?: ?boolean,
 }
+
 
 declare class Picker<T> extends React.Component<PickerProps<T>, {}> {
   /**


### PR DESCRIPTION
Add `preserveSpacesInLabel` property and  `preserveSpace` method to Picker.item in Dropdown (Web only)
In some cases (e.g. https://github.com/Expensify/App/issues/16329) users want to keep whitespace in Picker on Web (same as iOS and Android).

As on the web, a drop-down list is implemented using the <option> element and by default the HTML <option> element merges consecutive spaces into one space and cannot be changed, I added a helper method to achieve this goal and an additional prop based on which the users decide if they want to keep the whitespace or not.

![screen](https://user-images.githubusercontent.com/19835085/231188200-d70c3661-9f69-49a3-a68f-9701d735b14e.png)


