### PR TITLE
Fix: Add TestID for PickerWindows

### DIFF
--- a/js/PickerWindows.windows.js
+++ b/js/PickerWindows.windows.js
@@ -76,6 +76,7 @@ class PickerWindows extends React.Component<
           value: child.props.value,
           label: child.props.label,
           textColor: processColor(child.props.color),
+          testID: child.props.testID
         });
       },
     );

--- a/windows/ReactNativePicker/ReactPickerView.cpp
+++ b/windows/ReactNativePicker/ReactPickerView.cpp
@@ -9,6 +9,7 @@
 #include <winrt/Windows.Foundation.Metadata.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
 
 namespace winrt {
     using namespace Microsoft::ReactNative;
@@ -154,8 +155,12 @@ namespace winrt::ReactNativePicker::implementation {
             auto& labelObject = item.GetObjectProperty("label");
             if (!labelObject.IsNull()) {
                 auto comboBoxItem = winrt::ComboBoxItem();
+                auto textBlock = winrt::TextBlock();
                 auto label = to_hstring(labelObject.AsString());
-                comboBoxItem.Content(winrt::box_value(label));
+                
+                textBlock.Text(label);
+                xaml::Automation::AutomationProperties::SetName(textBlock, label);
+                comboBoxItem.Content(textBlock);
 
                 const auto& textColorObject = item.GetObjectProperty("textColor");
                 if (!textColorObject.IsNull()) {
@@ -169,6 +174,14 @@ namespace winrt::ReactNativePicker::implementation {
                 if (!valueObject.IsNull()) {
                     m_itemValues.emplace_back(to_hstring(valueObject.AsString()));
                 }
+
+                const auto& testIdObject = item.GetObjectProperty("testID");
+                if (!testIdObject.IsNull()) {
+                    auto testId = to_hstring(testIdObject.AsString());
+                    auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(testId);
+                    comboBoxItem.SetValue(xaml::Automation::AutomationProperties::AutomationIdProperty(), boxedValue);
+                    xaml::Automation::AutomationProperties::SetAutomationId(textBlock, testId);
+               }
 
                 comboBoxItems.Append(comboBoxItem);
             }


### PR DESCRIPTION
- Platform: Windows
- "@react-native-picker/picker": "^2.4.8"
- "react-native": "<=0.67.2"

Currently, when attempting to set the testID property on Picker Items, it does not function as expected on Windows platforms.