### PR TITLE
[Android] Fix invoking onSelect / onValueChange without user interaction

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPicker.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPicker.java
@@ -40,6 +40,26 @@ public class ReactPicker extends AppCompatSpinner {
   private int mOldElementSize = Integer.MIN_VALUE;
   private boolean mIsOpen = false;
 
+  @Override
+  public void setSelection(int position, boolean animate) {
+    boolean sameSelected = position == getSelectedItemPosition();
+    super.setSelection(position, animate);
+    if (sameSelected && mOnSelectListener != null) {
+      // Spinner does not call the OnItemSelectedListener if the same item is selected, so do it manually now
+      mOnSelectListener.onItemSelected(position);
+    }
+  }
+
+  @Override
+  public void setSelection(int position) {
+    boolean sameSelected = position == getSelectedItemPosition();
+    super.setSelection(position);
+    if (sameSelected && mOnSelectListener != null) {
+      // Spinner does not call the OnItemSelectedListener if the same item is selected, so do it manually now
+      mOnSelectListener.onItemSelected(position);
+    }
+  }
+
   private final OnItemSelectedListener mItemSelectedListener = new OnItemSelectedListener() {
     @Override
     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {


### PR DESCRIPTION
#### Problems encountered on Android:
- On initial render the onSelect / onValueChanged event is called without user interaction
- When initial values changes the the onSelect / onValueChanged event is called without user interaction
- User cannot select the same element on Android event when selected item on react site is different, e.g. user selects option 1, it fails, and user cannot select the same option to retry the action

#### Solutions:
- Allow to invoke onSelect / onValueChanged event only when user interaction happened, e.g. when component where opened by user. REMARK: On Android 8 to 10, unfortunately, order of events is broken and onBlur happens before onSelect / onValueChanged event. 
- Allow user to select the same element by invoking the event manually. 