### PR TITLE
(docs): Remove outdated Expo SDK version and related info

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@
 | >= 1.16.0 | 0.61+ | 0.61+ |
 | >= 1.2.0 | 0.60+ or 0.59+ with [Jetifier](https://www.npmjs.com/package/jetifier) | N/A |
 | >= 1.0.0 | 0.57 | N/A |
-
-## For Managed Workflow users using Expo 37
-This component is not supported in the managed workflow for expo sdk 37. Please import the `Picker` from `react-native`.
-See more info [here](https://github.com/react-native-picker/picker/issues/45#issuecomment-633163973)
    
 ## Getting started
 


### PR DESCRIPTION
In the README.md, the section about Expo SDK 37 seems irrelevant as its pretty old and the SDK version is no longer supported by the Expo team. Currently, the SDK versions supported are [46 to 49](https://docs.expo.dev/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).

This PR removes the section about managed Expo SDK 47.