### PR TITLE
Add code to hide dropdown icon on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPicker.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPicker.java
@@ -285,6 +285,19 @@ public class ReactPicker extends FabricEnabledPicker {
     backgroundDrawable.setColor(ColorStateList.valueOf(color));
   }
 
+  public void setDropdownIconVisible(@Nullable boolean visible) {
+    LayerDrawable drawable = (LayerDrawable) this.getBackground();
+    RippleDrawable backgroundDrawable = (RippleDrawable) drawable.findDrawableByLayerId(R.id.dropdown_icon);
+
+    if (visible) {
+      backgroundDrawable.setAlpha(255);
+    }
+    else {
+      backgroundDrawable.setAlpha(0);
+    }
+
+  }
+
   public void setBackgroundColor(@Nullable int color) {
     LayerDrawable drawable = (LayerDrawable) this.getBackground();
     GradientDrawable backgroundDrawable = (GradientDrawable) drawable.findDrawableByLayerId(R.id.dropdown_background);

--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
@@ -181,6 +181,11 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
     view.setDropdownIconRippleColor(color);
   }
 
+  @ReactProp(name = "dropdownIconVisible")
+  public void setDropdownIconVisible(ReactPicker view, @Nullable boolean visible) {
+    view.setDropdownIconVisible(visible);
+  }
+
   @ReactProp(name = ViewProps.NUMBER_OF_LINES, defaultInt = 1)
   public void setNumberOfLines(ReactPicker view, int numberOfLines) {
     ReactPickerAdapter adapter = (ReactPickerAdapter) view.getAdapter();

--- a/android/src/main/jni/conversions.h
+++ b/android/src/main/jni/conversions.h
@@ -50,6 +50,7 @@ namespace facebook
             values["backgroundColor"] = props.backgroundColor;
             values["dropdownIconColor"] = props.dropdownIconColor;
             values["dropdownIconRippleColor"] = props.dropdownIconRippleColor;
+            values["dropdownIconVisible"] = props.dropdownIconVisible;
             values["numberOfLines"] = props.numberOfLines;
             values["mode"] = "dialog";
 
@@ -97,6 +98,7 @@ namespace facebook
             values["backgroundColor"] = props.backgroundColor;
             values["dropdownIconColor"] = props.dropdownIconColor;
             values["dropdownIconRippleColor"] = props.dropdownIconRippleColor;
+            values["dropdownIconVisible"] = props.dropdownIconVisible;
             values["numberOfLines"] = props.numberOfLines;
             values["mode"] = "dropdown";
 

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDialogPickerManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDialogPickerManagerDelegate.java
@@ -47,6 +47,9 @@ public class RNCAndroidDialogPickerManagerDelegate<T extends View, U extends Bas
       case "dropdownIconRippleColor":
         mViewManager.setDropdownIconRippleColor(view, value == null ? 0 : ((Double) value).intValue());
         break;
+      case "dropdownIconVisible":
+        mViewManager.setDropdownIconVisible(view, value == null ? true : (boolean) value);
+        break;
       case "numberOfLines":
         mViewManager.setNumberOfLines(view, value == null ? 0 : ((Double) value).intValue());
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDialogPickerManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDialogPickerManagerInterface.java
@@ -22,6 +22,7 @@ public interface RNCAndroidDialogPickerManagerInterface<T extends View> {
   void setBackgroundColor(T view, int value);
   void setDropdownIconColor(T view, int value);
   void setDropdownIconRippleColor(T view, int value);
+  void setDropdownIconVisible(T view, boolean value);
   void setNumberOfLines(T view, int value);
   void focus(T view);
   void blur(T view);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDropdownPickerManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDropdownPickerManagerDelegate.java
@@ -47,6 +47,9 @@ public class RNCAndroidDropdownPickerManagerDelegate<T extends View, U extends B
       case "dropdownIconRippleColor":
         mViewManager.setDropdownIconRippleColor(view, value == null ? 0 : ((Double) value).intValue());
         break;
+      case "dropdownIconVisible":
+        mViewManager.setDropdownIconVisible(view, value == null ? true : (boolean) value);
+        break;
       case "numberOfLines":
         mViewManager.setNumberOfLines(view, value == null ? 0 : ((Double) value).intValue());
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDropdownPickerManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDropdownPickerManagerInterface.java
@@ -22,6 +22,7 @@ public interface RNCAndroidDropdownPickerManagerInterface<T extends View> {
   void setBackgroundColor(T view, int value);
   void setDropdownIconColor(T view, int value);
   void setDropdownIconRippleColor(T view, int value);
+  void setDropdownIconVisible(T view, boolean value);
   void setNumberOfLines(T view, int value);
   void focus(T view);
   void blur(T view);

--- a/js/AndroidDialogPickerNativeComponent.js
+++ b/js/AndroidDialogPickerNativeComponent.js
@@ -53,6 +53,7 @@ type NativeProps = $ReadOnly<{|
   backgroundColor?: Int32,
   dropdownIconColor?: Int32,
   dropdownIconRippleColor?: Int32,
+  dropdownIconVisible?: ?boolean,
   numberOfLines?: ?Int32,
   onSelect?: BubblingEventHandler<PickerAndroidChangeEvent, 'topSelect'>,
   onFocus?: BubblingEventHandler<null, 'topFocus'>,

--- a/js/AndroidDropdownPickerNativeComponent.js
+++ b/js/AndroidDropdownPickerNativeComponent.js
@@ -53,6 +53,7 @@ type NativeProps = $ReadOnly<{|
   backgroundColor?: Int32,
   dropdownIconColor?: Int32,
   dropdownIconRippleColor?: Int32,
+  dropdownIconVisible?: ?boolean,
   numberOfLines?: ?Int32,
   onSelect?: BubblingEventHandler<PickerAndroidChangeEvent, 'topSelect'>,
   onFocus?: BubblingEventHandler<null, 'topFocus'>,

--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -40,6 +40,7 @@ type PickerAndroidProps = $ReadOnly<{|
   prompt?: ?string,
   testID?: string,
   dropdownIconColor?: string,
+  dropdownIconVisible?: ?boolean,
   numberOfLines?: ?number,
 |}>;
 
@@ -230,6 +231,7 @@ function PickerAndroid(props: PickerAndroidProps, ref: PickerRef): React.Node {
     style: props.style,
     dropdownIconColor: processColor(props.dropdownIconColor),
     dropdownIconRippleColor: processColor(props.dropdownIconRippleColor),
+    dropdownIconVisible: props.dropdownIconVisible,
     testID: props.testID,
     numberOfLines: props.numberOfLines,
   };

--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -96,6 +96,11 @@ export interface PickerProps<T = ItemValue> extends ViewProps {
    */
   dropdownIconRippleColor?: number | ColorValue;
   /**
+   * Visibility of spinner's arrow
+   * @platform android
+   */
+  dropdownIconVisible?: boolean;
+  /**
    * On Android & iOS, used to truncate the text with an ellipsis after computing the text layout, including line wrapping,
    * such that the total number of lines does not exceed this number. Default is '1'
    * @platform android & iOS


### PR DESCRIPTION
Hey, I didn't find a way to hide the arrow icon on Android and I tried to fix that by adding a `dropdownIconVisible` option

I haven't had the chance to work in detail with native code in RN, so please give me some feedback if my code needs improvement