### PR TITLE
fix: revert change to java record

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerLocalData.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerLocalData.java
@@ -1,6 +1,15 @@
 package com.reactnativecommunity.picker;
 
-public record ReactPickerLocalData(int height) {
+public class ReactPickerLocalData {
+    private final int height;
+
+    public ReactPickerLocalData(int height) {
+        this.height = height;
+    }
+
+    public int getHeight() {
+        return height;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -8,6 +17,11 @@ public record ReactPickerLocalData(int height) {
         if (o == null || getClass() != o.getClass()) return false;
         ReactPickerLocalData that = (ReactPickerLocalData) o;
         return height == that.height;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 + height;
     }
 
     @Override

--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerShadowNode.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerShadowNode.java
@@ -7,6 +7,6 @@ public class ReactPickerShadowNode extends LayoutShadowNode {
     @Override
     public void setLocalData(Object data) {
         Assertions.assertCondition(data instanceof ReactPickerLocalData);
-        setStyleMinHeight(((ReactPickerLocalData) data).height());
+        setStyleMinHeight(((ReactPickerLocalData) data).getHeight());
     }
 }


### PR DESCRIPTION
Closes #555
Closes #556 
Closes #557

Revert `ReactPickerLocalData` back to a normal java class. 
Tested on 0.71, 0.72, 0.73, and 0.74