### PR TITLE
fix(android): build error on monorepo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ def resolveReactNativeDirectory() {
         return reactNativeFromProjectNodeModules
     }
 
-    def reactNativeFromNodeModulesWithPicker = file("${projectDir}/../../react-native")
+    def reactNativeFromNodeModulesWithPicker = file("${projectDir}/../../../react-native")
     if (reactNativeFromNodeModulesWithPicker.exists()) {
         return reactNativeFromNodeModulesWithPicker
     }


### PR DESCRIPTION
# Why

having the error when building on android with new architecture enabled and in a monorepo:

```
* What went wrong:
A problem occurred evaluating project ':react-native-picker_picker'.
> [react-native-picker] Unable to resolve react-native location in node_modules. You should add project extension property (in app/build.gradle) `REACT_NATIVE_NODE_MODULES_DIR` with path to react-native.
```

# How

the line should be referenced from other libraries but since the current npm package name is namespaced under `@react-native-picker/picker`, we should add more ".."

# Test Plan

```bash
#!/bin/bash

mkdir RN074Monorepo
cd RN074Monorepo
cat > package.json <<EOF
{
  "private": true,
  "workspaces": ["apps/*"]
}
EOF

mkdir apps
cd apps
npx @react-native-community/cli@latest init RN074 --version 0.74.0-rc.7 --skip-install
cd RN074
yarn add @react-native-picker/picker@2.7.2

# Fix react-native for monorepo
patch -p1 <<EOF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -11,11 +11,11 @@ react {
     //   The root of your project, i.e. where "package.json" lives. Default is '..'
     // root = file("../")
     //   The folder where the react-native NPM package is. Default is ../node_modules/react-native
-    // reactNativeDir = file("../node_modules/react-native")
+    reactNativeDir = file("../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../node_modules/@react-native/codegen
-    // codegenDir = file("../node_modules/@react-native/codegen")
+    codegenDir = file("../../../../node_modules/@react-native/codegen")
     //   The cli.js file which is the React Native CLI entrypoint. Default is ../node_modules/react-native/cli.js
-    // cliFile = file("../node_modules/react-native/cli.js")
+    cliFile = file("../../../../node_modules/react-native/cli.js")

     /* Variants */
     //   The list of variants to that are debuggable. For those we're going to
@@ -115,4 +115,4 @@ dependencies {
     }
 }

-apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: file("../../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'RN074'
-apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+apply from: file("../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
-includeBuild('../node_modules/@react-native/gradle-plugin')
+includeBuild('../../../node_modules/@react-native/gradle-plugin')
EOF

cd android
./gradlew -PnewArchEnabled=true :app:assembleDebug
```
