### PR TITLE
[Fabric] [iOS] Fix app crash when selecting an empty value

### DIFF
--- a/ios/RNCPicker.mm
+++ b/ios/RNCPicker.mm
@@ -157,7 +157,7 @@ numberOfRowsInComponent:(__unused NSInteger)component
           std::dynamic_pointer_cast<const facebook::react::RNCPickerEventEmitter>(eventEmitter)
               ->onChange(facebook::react::RNCPickerEventEmitter::OnChange{
                   .newIndex = (int)row,
-                  .newValue =  RCTStringFromNSString(RCTNullIfNil(_items[row][@"value"])),
+                  .newValue =  RCTStringFromNSString(_items[row][@"value"]),
               });
         }
 }

--- a/ios/RNCPickerComponentView.mm
+++ b/ios/RNCPickerComponentView.mm
@@ -48,7 +48,7 @@ UIPickerViewDelegate
     for (RNCPickerItemsStruct item : newProps.items)
     {
         NSMutableDictionary *dictItem = [NSMutableDictionary new];
-        dictItem[@"value"] = RCTNSStringFromStringNilIfEmpty(item.value);
+        dictItem[@"value"] = RCTNSStringFromString(item.value);
         dictItem[@"label"] = RCTNSStringFromStringNilIfEmpty(item.label);
         dictItem[@"textColor"] = RCTUIColorFromSharedColor(item.textColor);
         dictItem[@"testID"] = RCTNSStringFromStringNilIfEmpty(item.testID);


### PR DESCRIPTION
Selecting an item with an empty value crashes the app because we convert an empty string to null,
https://github.com/react-native-picker/picker/blob/7b7a95f4fe842d0a0c696310f9f10a8267247227/ios/RNCPickerComponentView.mm#L51

and it crashes here.
https://github.com/react-native-picker/picker/blob/7b7a95f4fe842d0a0c696310f9f10a8267247227/ios/RNCPicker.mm#L160

## Test
1. Run the example app with `RCT_NEW_ARCH_ENABLED` enabled
2. Add a picker item with an empty value to the example
3. Scroll the picker to select the item with an empty value
