### PR TITLE
Delete deprecated receiveCommand for INT

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
@@ -218,23 +218,6 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
   }
 
   @Override
-  public void receiveCommand(@NonNull ReactPicker root, int commandId, @androidx.annotation.Nullable ReadableArray args) {
-    switch (commandId) {
-      case FOCUS_PICKER:
-        root.performClick();
-        break;
-      case BLUR_PICKER:
-        root.clearFocus();
-        break;
-      case SET_NATIVE_SELECTED:
-        Assertions.assertNotNull(args);
-        assert args != null;
-        setNativeSelected(root, args.getInt(0));
-        break;
-    }
-  }
-
-  @Override
   public void receiveCommand(@NonNull ReactPicker root, String commandId, @androidx.annotation.Nullable ReadableArray args) {
     Assertions.assertNotNull(root);
     switch (commandId) {
@@ -355,7 +338,7 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
       convertView.setEnabled(enabled);
       // Seems counter intuitive, but this makes the specific item not clickable when enable={false}
       convertView.setClickable(!enabled);
-      
+
       final TextView textView = (TextView) convertView;
       textView.setText(item.getString("label"));
       textView.setMaxLines(mNumberOfLines);
@@ -366,7 +349,7 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
         } else {
           convertView.setBackgroundColor(Color.TRANSPARENT);
         }
-        
+
         if (style.hasKey("color") && !style.isNull("color")) {
           textView.setTextColor(style.getInt("color"));
         }


### PR DESCRIPTION
`receiveCommand(@NonNull ReactPicker root, int commandId, @androidx.annotation.Nullable ReadableArray args)` 
for INT was deprecated 5 years ago in favour of 
`receiveCommand(@NonNull ReactPicker root, String commandId, @androidx.annotation.Nullable ReadableArray args)`

This is needed to get rid of `dispatchCommand` INT variant here : https://github.com/facebook/react-native/blob/044aadbaf6830b21aab821804dc5a7989010022e/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java#L591-L595

The usages in [@react-native-picker/picker](https://github.com/react-native-picker/picker/) are [all](https://github.com/search?q=repo%3Areact-native-picker%2Fpicker%20receiveCommand&type=code) dependent on String variant

