### PR TITLE
fix: resolve android crash issue if props are undefined

### DIFF
--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -200,8 +200,10 @@ function PickerAndroid(props: PickerAndroidProps, ref: PickerRef): React.Node {
           const children = React.Children.toArray(props.children).filter(
             (item) => item != null,
           );
-          const value = children[position].props.value;
-          onValueChange(value, position);
+          const value = children[position]?.props?.value;
+          if (value) {
+            onValueChange(value, position);
+          }
         } else {
           onValueChange(null, position);
         }


### PR DESCRIPTION
In some cases, children are not available yet or props are undefined in Android which causes the app to crash