### PR TITLE
📝 Update README.md to make previews more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 [![npm version](https://img.shields.io/npm/v/@react-native-picker/picker.svg)](https://www.npmjs.com/package/@react-native-picker/picker)
 [![Build](https://github.com/react-native-picker/picker/workflows/Build/badge.svg)](https://github.com/react-native-picker/picker/actions) ![Supports Android, iOS, MacOS, and Windows](https://img.shields.io/badge/platforms-android%20|%20ios|%20macos|%20windows-lightgrey.svg) ![MIT License](https://img.shields.io/npm/l/@react-native-picker/picker.svg) [![Lean Core Extracted](https://img.shields.io/badge/Lean%20Core-Extracted-brightgreen.svg)](https://github.com/facebook/react-native/issues/23313)
 
-| Android | iOS | PickerIOS | Windows | MacOS |
-| --- | --- | --- | --- | --- |
-| <img src="./screenshots/picker-android.png" width="150"> | <img src="./screenshots/picker-ios.png" width="150"> | <img src="./screenshots/pickerios-ios.png" width="150"> | <img src="./screenshots/picker-windows.png" width="300"> | <img src="./screenshots/picker-macos.png" width="300">
+| Android | iOS | PickerIOS |
+| --- | --- | --- |
+| <img src="./screenshots/picker-android.png" width="220"> | <img src="./screenshots/picker-ios.png" width="220"> | <img src="./screenshots/pickerios-ios.png" width="220">
+
+| Windows | MacOS |
+| --- | --- |
+| <img src="./screenshots/picker-windows.png" width="344"> | <img src="./screenshots/picker-macos.png" width="344">
 
 ## Supported Versions
 


### PR DESCRIPTION
Currently, the previews are in one line and are not visible, unless zoomed in or clicked on. This way can add extra steps to view one simple image

before:
![image](https://github.com/react-native-picker/picker/assets/35927429/2b948ee0-54f3-4b38-ad6e-bb5c8c590cdb)

after:
![image](https://github.com/react-native-picker/picker/assets/35927429/14f56fd0-80aa-4bea-970a-79afc8b65fef)

