### PR TITLE
fix(#310): missing a11y label and hint props on iOS Picker

### DIFF
--- a/ios/RNCPicker.mm
+++ b/ios/RNCPicker.mm
@@ -10,7 +10,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 
-@interface RNCPicker() <UIPickerViewDataSource, UIPickerViewDelegate>
+@interface RNCPicker() <UIPickerViewDataSource, UIPickerViewDelegate, UIPickerViewAccessibilityDelegate>
 @end
 
 @implementation RNCPicker
@@ -146,6 +146,19 @@ numberOfRowsInComponent:(__unused NSInteger)component
     });
   }
 }
+
+#pragma mark - UIPickerViewAccessibilityDelegate
+
+- (NSString *)pickerView:(UIPickerView *)pickerView accessibilityLabelForComponent:(NSInteger)component
+{
+    return self.accessibilityLabel;
+}
+
+- (NSString *)pickerView:(UIPickerView *)pickerView accessibilityHintForComponent:(NSInteger)component
+{
+    return self.accessibilityHint;
+}
+
 
 #ifdef RCT_NEW_ARCH_ENABLED
 - (void)pickerView:(__unused UIPickerView *)pickerView

--- a/js/PickerIOS.ios.js
+++ b/js/PickerIOS.ios.js
@@ -113,6 +113,8 @@ const PickerIOSWithForwardedRef: React.AbstractComponent<
     onChange,
     onValueChange,
     style,
+    accessibilityLabel,
+    accessibilityHint,
   } = props;
 
   const nativePickerRef = React.useRef<React.ElementRef<
@@ -199,6 +201,8 @@ const PickerIOSWithForwardedRef: React.AbstractComponent<
         ref={ref}
         themeVariant={themeVariant}
         testID={testID}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
         style={[styles.pickerIOS, itemStyle]}
         // $FlowFixMe
         items={items}


### PR DESCRIPTION
This PR adds missing accessibilityLabel and accessibilityHint props on iOS Picker component. The solution uses UIPickerViewAccessibilityDelegate which uses values from accessibilityLabel and accessibilityHint JS props.

closes #310 

Attaching two recordings, one before fix and one after fix.
By default VoiceOver announces the text of selected picker item, then it announces "picker item", then it announces "adjustable" accessibilityRole, then it announces item's position in collection, e.g. 1 of 3. After that it announces default hint for swiping picker up or down to change selected item.
After fix, Voiceover will first announce the accessibilityLabel value, then the text of selected picker item, then it announces "picker item", then it announces "adjustable" accessibilityRole, then it announces item's position in collection, e.g. 1 of 3. After that it announces the accessibilityHint value followed by default hint for swiping picker up or down to change selected item.

Before:

https://github.com/user-attachments/assets/b3bca205-5bd8-456f-b46f-782df7dcce86

After:

https://github.com/user-attachments/assets/a7717f95-7877-418e-8c81-a6dd044075fd

