### PR TITLE
feat: Add support for react-native 0.76.0

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -22,7 +22,7 @@ file(GLOB LIB_CODEGEN_SRCS CONFIGURE_DEPENDS ${LIB_ANDROID_GENERATED_COMPONENTS_
 
 add_library(
   ${LIB_TARGET_NAME}
-  SHARED 
+  SHARED
   ${LIB_CUSTOM_SRCS}
   ${LIB_CODEGEN_SRCS}
 )
@@ -35,25 +35,34 @@ target_include_directories(
   ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
 )
 
-target_link_libraries(
-  ${LIB_TARGET_NAME}
-  fbjni
-  folly_runtime
-  glog
-  jsi
-  react_codegen_rncore
-  react_debug
-  react_nativemodule_core
-  react_render_componentregistry
-  react_utils
-  react_render_core
-  react_render_debug
-  react_render_graphics
-  react_render_mapbuffer
-  rrc_view
-  turbomodulejsijni
-  yoga
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+  target_link_libraries(
+    ${LIB_TARGET_NAME}
+    ReactAndroid::reactnative
+    ReactAndroid::jsi
+    fbjni::fbjni
+  )
+else()
+  target_link_libraries(
+    ${LIB_TARGET_NAME}
+    fbjni
+    folly_runtime
+    glog
+    jsi
+    react_codegen_rncore
+    react_debug
+    react_nativemodule_core
+    react_render_componentregistry
+    react_utils
+    react_render_core
+    react_render_debug
+    react_render_graphics
+    react_render_mapbuffer
+    rrc_view
+    turbomodulejsijni
+    yoga
+  )
+endif()
 
 target_compile_options(
   ${LIB_TARGET_NAME}


### PR DESCRIPTION
Due to the introduction of `libreactnative.so` in 0.76 we must update the `CMakeLists.txt
` file to be compatible with merged libraries, more details can be found at https://github.com/react-native-community/discussions-and-proposals/discussions/816

This PR can be tested through the update of the FabricExample, here -> https://github.com/react-native-picker/picker/pull/587