### PR TITLE
fix: Adds object as a type on type ItemValue

### DIFF
--- a/typings/Picker.d.ts
+++ b/typings/Picker.d.ts
@@ -9,7 +9,7 @@ import type {
 } from 'react-native';
 import { processColor } from 'react-native';
 
-export type ItemValue = number | string;
+export type ItemValue = number | string | object;
 
 export interface PickerItemProps<T = ItemValue> {
   label?: string;


### PR DESCRIPTION
Allows to set a Picker Item value to an object and be able to do something with the selected itemValue on the onValueChange callback function