### PR TITLE
fix: Add deprecated receiveCommand method

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactPickerManager.java
@@ -218,6 +218,17 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
   }
 
   @Override
+  public void receiveCommand(@NonNull ReactPicker root, int commandId, @androidx.annotation.Nullable ReadableArray args) {
+    Map<String, Integer> commands = getCommandsMap();
+    if(commands == null) return;
+    for (Map.Entry<String, Integer> entry : commands.entrySet()) {
+      if (commandId == entry.getValue()) {
+        receiveCommand(root, entry.getKey(), args);
+      }
+    }
+  }
+
+  @Override
   public void receiveCommand(@NonNull ReactPicker root, String commandId, @androidx.annotation.Nullable ReadableArray args) {
     Assertions.assertNotNull(root);
     switch (commandId) {


### PR DESCRIPTION
Support deprecated receiveCommand which receives commandId as int.

It may be RN bug and also dependent on RN version, but running on RN 0.76.2 (old arch), the `receiveCommand` which accepts `String commandId` is never called, therefore calling `focus()` and `blur()` functions does nothing. Here we manually delegate this call using the deprecated `receiveCommand`. JS sends the command id as Int.