### PR TITLE
fix: setting nullish values on android

### DIFF
--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -201,7 +201,7 @@ function PickerAndroid(props: PickerAndroidProps, ref: PickerRef): React.Node {
             (item) => item != null,
           );
           const value = children[position]?.props?.value;
-          if (value) {
+          if (value !== undefined) {
             onValueChange(value, position);
           }
         } else {


### PR DESCRIPTION
Fixes #590

There was a breaking change introduced [here](https://github.com/react-native-picker/picker/commit/243ead2e226ea5441a7091beccc903e804922c18#diff-3f055065a2b6ec0273bd0a4500979cb49e13dee44504e0d2a3015d8d312637d4L203) that didn't allow the picker to set to nullish values on Android.

I've tested this change locally and it solves the issue