### PR TITLE
Fix: Prevent 'TypeError: Cannot read property 'value' of undefined' in Picker Component

### DIFF
--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -111,7 +111,7 @@ function PickerAndroid(props: PickerAndroidProps, ref: PickerRef): React.Node {
       if (child === null) {
         return null;
       }
-      if (child.props.value === props.selectedValue) {
+      if (child?.props?.value === props.selectedValue) {
         jsValue = index;
       }
     });
@@ -159,13 +159,13 @@ function PickerAndroid(props: PickerAndroidProps, ref: PickerRef): React.Node {
       if (child === null) {
         return null;
       }
-      if (child.props.value === props.selectedValue) {
+      if (child?.props?.value === props.selectedValue) {
         selected = index;
       }
 
-      const {enabled = true} = child.props;
+      const {enabled = true} = child.props || {};
 
-      const {color, contentDescription, label, style = {}} = child.props;
+      const {color, contentDescription, label, style = {}} = child.props || {};
 
       const processedColor = processColor(color);
 


### PR DESCRIPTION
While working on a simple task in my React Native Expo application, I encountered an issue when using a picker component. The error was observed on my Android device during runtime.

**Problem**
The error message suggested a potential issue with null or undefined values being passed to the picker. After investigating further, I discovered that the value prop for some Picker.Item components was not being validated properly in this case if an empty string was passed. Causing the application to crash in specific scenarios.

**Code Snippet**
```
<View style={styles.dropdownContainer}>
     <Text style={styles.label}>City / Region</Text>
      <Picker
            selectedValue={city}
            style={styles.picker}
            onValueChange={(itemValue) => {
              setCity(itemValue);
              setArea("");
            }}
          >
          <Picker.Item label="Select City" value="" />
          <Picker.Item label="Lahore" value="Lahore" />
          <Picker.Item label="Faisalabad" value="Faisalabad" />
      </Picker>
 </View>
```
**Solution**
To address this, I implemented null checks in the code to ensure that value prop is validated properly. I thoroughly tested the fix  locally and confirmed that the issue no longer occurs on Andriod devices.
        
![94a33faf-e29d-4351-aa29-9952bb05b46a](https://github.com/user-attachments/assets/8a46fb01-75e4-4634-acc8-7a97034c77e5)
