### PR TITLE
feat: support RN 0.77

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDialogPickerManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDialogPickerManagerDelegate.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.BaseViewManagerDelegate;
 
 public class RNCAndroidDialogPickerManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & RNCAndroidDialogPickerManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public RNCAndroidDialogPickerManagerDelegate(U viewManager) {

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDialogPickerManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDialogPickerManagerDelegate.java
@@ -13,10 +13,10 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.uimanager.BaseViewManagerDelegate;
-import com.facebook.react.uimanager.BaseViewManagerInterface;
+import com.facebook.react.uimanager.BaseViewManager;
+import com.facebook.react.uimanager.LayoutShadowNode;
 
-public class RNCAndroidDialogPickerManagerDelegate<T extends View, U extends BaseViewManagerInterface<T> & RNCAndroidDialogPickerManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
+public class RNCAndroidDialogPickerManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & RNCAndroidDialogPickerManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public RNCAndroidDialogPickerManagerDelegate(U viewManager) {
     super(viewManager);
   }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDropdownPickerManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCAndroidDropdownPickerManagerDelegate.java
@@ -13,10 +13,11 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.BaseViewManager;
+import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
-import com.facebook.react.uimanager.BaseViewManagerInterface;
 
-public class RNCAndroidDropdownPickerManagerDelegate<T extends View, U extends BaseViewManagerInterface<T> & RNCAndroidDropdownPickerManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
+public class RNCAndroidDropdownPickerManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & RNCAndroidDropdownPickerManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public RNCAndroidDropdownPickerManagerDelegate(U viewManager) {
     super(viewManager);
   }


### PR DESCRIPTION
needed to support RN 77 because of https://github.com/facebook/react-native/pull/46809
this only influences old architecture, not new

tested locally

