### PR TITLE
fix(ios): question marks rendered unexpectedly (RN >= 0.77)

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,11 @@
     "jsSrcsDir": "./js",
     "android": {
       "javaPackageName": "com.reactnativecommunity.picker"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNCPicker": "RNCPickerComponentView"
+      }
     }
   },
   "workspaces": [


### PR DESCRIPTION
Hello! 👋

This PR addresses an issue where, on iOS with React Native >= 0.77:

- Picker items display as question marks (?)
- Items cannot be selected


closes #631 
closes #612
closes #625

Reference: [react-native-picker/picker#612](https://github.com/react-native-picker/picker/issues/612)

⚠️ I haven't had the chance to test for backward compatibility.
I'm also not deeply familiar with the codebase, so please feel free to adjust or reject as needed.

Thanks!