### PR TITLE
fix(ios): Set delegate properly in new architecture to resolve question marks display issue

### DIFF
--- a/ios/RNCPicker.mm
+++ b/ios/RNCPicker.mm
@@ -27,7 +27,7 @@
     _textAlign = NSTextAlignmentCenter;
     _numberOfLines = 1;
 #ifdef RCT_NEW_ARCH_ENABLED
-  // nothing
+  self.delegate = self;
 #else
     self.delegate = self;
 #endif


### PR DESCRIPTION
## Description

Fixes an issue where the iOS picker displays question marks (?) instead of actual item labels when using React Native's new architecture (Fabric).

## Problem

In React Native 0.80.x with the new architecture enabled, the picker delegate was not being properly set, causing the picker to display question marks instead of the actual item labels. This only affected iOS - Android worked fine.

## Root Cause

The `RCT_NEW_ARCH_ENABLED` code path had a comment `// nothing` instead of properly setting the delegate, while the legacy architecture path correctly set `self.delegate = self`.

## Solution

Added the missing `self.delegate = self;` assignment in the `RCT_NEW_ARCH_ENABLED` code path to match the behavior of the legacy architecture.

## Changes

- **File**: `ios/RNCPicker.mm`
- **Change**: Replace `// nothing` comment with `self.delegate = self;` in the new architecture initialization

```diff
#ifdef RCT_NEW_ARCH_ENABLED
-  // nothing
+  self.delegate = self;
#else
    self.delegate = self;
#endif
```

## Testing

- ✅ Verified the fix resolves the question marks display issue
- ✅ Ensures consistent behavior between old and new architecture
- ✅ No breaking changes to existing functionality

## Closes

Fixes #639

## Checklist

- [x] The code follows the project's coding standards
- [x] I have tested the changes on iOS
- [x] The fix is minimal and focused on the specific issue
- [x] No breaking changes introduced
- [x] Issue number referenced in commit message