### PR TITLE
Do not use deprecated `ContextContainer::Shared`

### DIFF
--- a/android/src/main/jni/RNCAndroidDialogPickerMeasurementsManager.h
+++ b/android/src/main/jni/RNCAndroidDialogPickerMeasurementsManager.h
@@ -12,7 +12,7 @@ namespace facebook::react {
 class RNCAndroidDialogPickerMeasurementsManager {
  public:
   RNCAndroidDialogPickerMeasurementsManager(
-      const ContextContainer::Shared& contextContainer)
+      const std::shared_ptr<const ContextContainer> &contextContainer)
       : contextContainer_(contextContainer) {}
 
   Size measure(
@@ -22,6 +22,6 @@ class RNCAndroidDialogPickerMeasurementsManager {
       RNCAndroidDialogPickerState state) const;
 
  private:
-  const ContextContainer::Shared contextContainer_;
+  const std::shared_ptr<const ContextContainer> contextContainer_;
 };
 } // namespace facebook::react

--- a/android/src/main/jni/RNCAndroidDropdownPickerMeasurementsManager.h
+++ b/android/src/main/jni/RNCAndroidDropdownPickerMeasurementsManager.h
@@ -12,7 +12,7 @@ namespace facebook::react {
 class RNCAndroidDropdownPickerMeasurementsManager {
  public:
   RNCAndroidDropdownPickerMeasurementsManager(
-      const ContextContainer::Shared& contextContainer)
+      const std::shared_ptr<const ContextContainer> &contextContainer)
       : contextContainer_(contextContainer) {}
 
   Size measure(
@@ -22,7 +22,7 @@ class RNCAndroidDropdownPickerMeasurementsManager {
       RNCAndroidDropdownPickerState state) const;
 
  private:
-  const ContextContainer::Shared contextContainer_;
+  const std::shared_ptr<const ContextContainer> contextContainer_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Using `ContextContainer::Shared` is deprecated, and is making the build against `react-native@nightly` failed because of a C++ warning.