### PR TITLE
fix: android crash on React Native 0.81 & new arch

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -64,15 +64,19 @@ else()
   )
 endif()
 
-target_compile_options(
-  ${LIB_TARGET_NAME}
-  PRIVATE
-  -DLOG_TAG=\"ReactNative\"
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)
+else()
+  target_compile_options(
+    ${LIB_TARGET_NAME}
+    PRIVATE
+    -DLOG_TAG=\"ReactNative\"
+    -fexceptions
+    -frtti
+    -std=c++20
+    -Wall
+  )
+endif()
 
 target_include_directories(
  ${CMAKE_PROJECT_NAME}


### PR DESCRIPTION
Fixes: https://github.com/react-native-picker/picker/issues/647 https://github.com/react-native-picker/picker/issues/642

As specified in the React Native [Changelog](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#android-specific-10)

> *CMake*: Correctly propagate `RN_SERIALIZABLE_STATE` to 3rd party `CMake` targets. Users with custom `CMake` and C++ code should update to use `target_compile_reactnative_options` inside their `CMakeLists.txt` files

every lib with custom CMakeLists.tsx should use `target_compile_reactnative_options` since 0.81